### PR TITLE
[Merged by Bors] - Add support for `order` parameter for `ListConnections`

### DIFF
--- a/src/core/types.rs
+++ b/src/core/types.rs
@@ -1,7 +1,7 @@
 mod api_key;
 mod paginated_list;
-mod pagination_order;
+mod pagination_options;
 
 pub use api_key::*;
 pub use paginated_list::*;
-pub use pagination_order::*;
+pub use pagination_options::*;

--- a/src/core/types.rs
+++ b/src/core/types.rs
@@ -1,5 +1,7 @@
 mod api_key;
 mod paginated_list;
+mod pagination_order;
 
 pub use api_key::*;
 pub use paginated_list::*;
+pub use pagination_order::*;

--- a/src/core/types/pagination_options.rs
+++ b/src/core/types/pagination_options.rs
@@ -1,5 +1,28 @@
 use serde::Serialize;
 
+/// The options used to control pagination for a given paginated endpoint.
+#[derive(Debug, Serialize)]
+pub struct PaginationOptions<'a> {
+    /// The order in which records should be paginated.
+    pub order: &'a PaginationOrder,
+
+    /// The cursor after which records should be retrived.
+    pub after: &'a Option<String>,
+
+    /// The cursor before which records should be retrieved.
+    pub before: &'a Option<String>,
+}
+
+impl<'a> Default for PaginationOptions<'a> {
+    fn default() -> Self {
+        Self {
+            order: &PaginationOrder::DEFAULT,
+            before: &None,
+            after: &None,
+        }
+    }
+}
+
 /// The order in which records should be returned when paginating.
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "snake_case")]
@@ -20,10 +43,10 @@ impl PaginationOrder {
 mod test {
     use serde_json::json;
 
-    use super::PaginationOrder;
+    use crate::PaginationOrder;
 
     #[test]
-    fn it_properly_serializes_asc() {
+    fn pagination_order_properly_serializes_asc() {
         assert_eq!(
             serde_json::to_string(&PaginationOrder::Asc).unwrap(),
             json!("asc").to_string()
@@ -31,7 +54,7 @@ mod test {
     }
 
     #[test]
-    fn it_properly_serializes_desc() {
+    fn pagination_order_properly_serializes_desc() {
         assert_eq!(
             serde_json::to_string(&PaginationOrder::Desc).unwrap(),
             json!("desc").to_string()

--- a/src/core/types/pagination_order.rs
+++ b/src/core/types/pagination_order.rs
@@ -1,0 +1,40 @@
+use serde::Serialize;
+
+/// The order in which records should be returned when paginating.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PaginationOrder {
+    /// Records are returned in ascending order.
+    Asc,
+
+    /// Records are returned in descending order.
+    Desc,
+}
+
+impl PaginationOrder {
+    /// The default order to use for pagination.
+    pub(crate) const DEFAULT: PaginationOrder = PaginationOrder::Desc;
+}
+
+#[cfg(test)]
+mod test {
+    use serde_json::json;
+
+    use super::PaginationOrder;
+
+    #[test]
+    fn it_properly_serializes_asc() {
+        assert_eq!(
+            serde_json::to_string(&PaginationOrder::Asc).unwrap(),
+            json!("asc").to_string()
+        )
+    }
+
+    #[test]
+    fn it_properly_serializes_desc() {
+        assert_eq!(
+            serde_json::to_string(&PaginationOrder::Desc).unwrap(),
+            json!("desc").to_string()
+        )
+    }
+}

--- a/src/sso/operations/list_connections.rs
+++ b/src/sso/operations/list_connections.rs
@@ -74,7 +74,6 @@ mod test {
             .build();
 
         let _mock = mock("GET", "/connections")
-            .match_query(Matcher::UrlEncoded("order".to_string(), "desc".to_string()))
             .match_header("Authorization", "Bearer sk_example_123456789")
             .with_status(200)
             .with_body(

--- a/src/sso/operations/list_connections.rs
+++ b/src/sso/operations/list_connections.rs
@@ -102,8 +102,8 @@ mod test {
                     }
                   ],
                   "list_metadata": {
-                    "before": "conn_01E2NPPCT7XQ2MVVYDHWGK1WN4",
-                    "after": null
+                    "after": "conn_01E2NPPCT7XQ2MVVYDHWGK1WN4",
+                    "before": null
                   }
                 })
                 .to_string(),
@@ -117,7 +117,7 @@ mod test {
             .unwrap();
 
         assert_eq!(
-            paginated_list.metadata.before,
+            paginated_list.metadata.after,
             Some("conn_01E2NPPCT7XQ2MVVYDHWGK1WN4".to_string())
         )
     }
@@ -151,8 +151,8 @@ mod test {
                     }
                   ],
                   "list_metadata": {
-                    "before": "conn_01E2NPPCT7XQ2MVVYDHWGK1WN4",
-                    "after": null
+                    "after": "conn_01E2NPPCT7XQ2MVVYDHWGK1WN4",
+                    "before": null
                   }
                 })
                 .to_string(),

--- a/src/sso/operations/list_connections.rs
+++ b/src/sso/operations/list_connections.rs
@@ -2,26 +2,24 @@ use async_trait::async_trait;
 use serde::Serialize;
 
 use crate::sso::{Connection, ConnectionType, Sso};
-use crate::{KnownOrUnknown, PaginatedList, PaginationOrder, WorkOsResult};
+use crate::{KnownOrUnknown, PaginatedList, PaginationOptions, WorkOsResult};
 
 #[derive(Debug, Serialize)]
 pub struct ListConnectionsOptions<'a> {
+    /// The pagination options to use when listing Connections.
+    #[serde(flatten)]
+    pub pagination: PaginationOptions<'a>,
+
+    /// The type of Connections to list.
     #[serde(rename = "connection_type")]
     pub r#type: &'a Option<KnownOrUnknown<ConnectionType, String>>,
-    pub before: &'a Option<String>,
-    pub after: &'a Option<String>,
-
-    /// The order in which Connections should be paginated.
-    pub order: &'a PaginationOrder,
 }
 
 impl<'a> Default for ListConnectionsOptions<'a> {
     fn default() -> Self {
         Self {
+            pagination: PaginationOptions::default(),
             r#type: &None,
-            before: &None,
-            after: &None,
-            order: &PaginationOrder::DEFAULT,
         }
     }
 }

--- a/src/sso/operations/list_connections.rs
+++ b/src/sso/operations/list_connections.rs
@@ -12,7 +12,7 @@ pub struct ListConnectionsOptions<'a> {
     pub after: &'a Option<String>,
 
     /// The order in which Connections should be paginated.
-    pub order: &'a Option<PaginationOrder>,
+    pub order: &'a PaginationOrder,
 }
 
 impl<'a> Default for ListConnectionsOptions<'a> {
@@ -21,7 +21,7 @@ impl<'a> Default for ListConnectionsOptions<'a> {
             r#type: &None,
             before: &None,
             after: &None,
-            order: &Some(PaginationOrder::DEFAULT),
+            order: &PaginationOrder::DEFAULT,
         }
     }
 }

--- a/src/sso/operations/list_connections.rs
+++ b/src/sso/operations/list_connections.rs
@@ -74,6 +74,7 @@ mod test {
             .build();
 
         let _mock = mock("GET", "/connections")
+            .match_query(Matcher::UrlEncoded("order".to_string(), "desc".to_string()))
             .match_header("Authorization", "Bearer sk_example_123456789")
             .with_status(200)
             .with_body(

--- a/src/sso/operations/list_connections.rs
+++ b/src/sso/operations/list_connections.rs
@@ -2,7 +2,7 @@ use async_trait::async_trait;
 use serde::Serialize;
 
 use crate::sso::{Connection, ConnectionType, Sso};
-use crate::{KnownOrUnknown, PaginatedList, WorkOsResult};
+use crate::{KnownOrUnknown, PaginatedList, PaginationOrder, WorkOsResult};
 
 #[derive(Debug, Serialize)]
 pub struct ListConnectionsOptions<'a> {
@@ -10,6 +10,9 @@ pub struct ListConnectionsOptions<'a> {
     pub r#type: &'a Option<KnownOrUnknown<ConnectionType, String>>,
     pub before: &'a Option<String>,
     pub after: &'a Option<String>,
+
+    /// The order in which Connections should be paginated.
+    pub order: &'a Option<PaginationOrder>,
 }
 
 impl<'a> Default for ListConnectionsOptions<'a> {
@@ -18,6 +21,7 @@ impl<'a> Default for ListConnectionsOptions<'a> {
             r#type: &None,
             before: &None,
             after: &None,
+            order: &Some(PaginationOrder::DEFAULT),
         }
     }
 }
@@ -72,6 +76,7 @@ mod test {
             .build();
 
         let _mock = mock("GET", "/connections")
+            .match_query(Matcher::UrlEncoded("order".to_string(), "desc".to_string()))
             .match_header("Authorization", "Bearer sk_example_123456789")
             .with_status(200)
             .with_body(


### PR DESCRIPTION
This PR adds support for the `order` parameter for `ListConnections`.

The pagination concerns have also been factored out into the new `PaginationOptions` so that we can reuse them for all of the list endpoints without repeating ourselves.