### PR TITLE
[Merged by Bors] - Add timestamps to objects

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2021"
 
 [dependencies]
 async-trait = "0.1"
+chrono = { version = "0.4", features = ["serde"] }
 querystring = "1.1"
 reqwest = { version = "0.11", features = ["json"] }
 serde = { version = "1.0", features = ["derive"] }

--- a/src/core/types.rs
+++ b/src/core/types.rs
@@ -1,7 +1,9 @@
 mod api_key;
 mod paginated_list;
 mod pagination_options;
+mod timestamps;
 
 pub use api_key::*;
 pub use paginated_list::*;
 pub use pagination_options::*;
+pub use timestamps::*;

--- a/src/core/types/timestamps.rs
+++ b/src/core/types/timestamps.rs
@@ -1,0 +1,12 @@
+use chrono::{DateTime, FixedOffset};
+use serde::{Deserialize, Serialize};
+
+/// The timestamps for an object.
+#[derive(Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct Timestamps {
+    /// The timestamp indicating when the object was created.
+    pub created_at: DateTime<FixedOffset>,
+
+    /// The timestamp indicating when the object was last updated.
+    pub updated_at: DateTime<FixedOffset>,
+}

--- a/src/organizations/types/organization.rs
+++ b/src/organizations/types/organization.rs
@@ -34,7 +34,7 @@ pub struct Organization {
     pub allow_profiles_outside_organization: bool,
     pub domains: Vec<OrganizationDomain>,
 
-    /// The timestamps for the connection.
+    /// The timestamps for the organization.
     #[serde(flatten)]
     pub timestamps: Timestamps,
 }

--- a/src/organizations/types/organization.rs
+++ b/src/organizations/types/organization.rs
@@ -2,6 +2,8 @@ use std::fmt::Display;
 
 use serde::{Deserialize, Serialize};
 
+use crate::Timestamps;
+
 /// The ID of an [`Organization`].
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 pub struct OrganizationId(String);
@@ -31,6 +33,10 @@ pub struct Organization {
     pub name: String,
     pub allow_profiles_outside_organization: bool,
     pub domains: Vec<OrganizationDomain>,
+
+    /// The timestamps for the connection.
+    #[serde(flatten)]
+    pub timestamps: Timestamps,
 }
 
 /// The ID of an [`OrganizationDomain`].

--- a/src/sso/types/connection.rs
+++ b/src/sso/types/connection.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::organizations::OrganizationId;
 use crate::sso::ConnectionType;
-use crate::KnownOrUnknown;
+use crate::{KnownOrUnknown, Timestamps};
 
 /// The ID of a [`Connection`].
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
@@ -57,15 +57,20 @@ pub struct Connection {
 
     /// The state of the connection.
     pub state: ConnectionState,
+
+    /// The timestamps for the connection.
+    #[serde(flatten)]
+    pub timestamps: Timestamps,
 }
 
 #[cfg(test)]
 mod test {
+    use chrono::DateTime;
     use serde_json::json;
 
-    use crate::organizations::OrganizationId;
     use crate::sso::ConnectionType;
     use crate::KnownOrUnknown;
+    use crate::{organizations::OrganizationId, Timestamps};
 
     use super::{Connection, ConnectionId, ConnectionState};
 
@@ -94,6 +99,10 @@ mod test {
                 r#type: KnownOrUnknown::Known(ConnectionType::GoogleOauth),
                 name: "Foo Corp".to_string(),
                 state: ConnectionState::Active,
+                timestamps: Timestamps {
+                    created_at: DateTime::parse_from_rfc3339("2021-06-25T19:07:33.155Z").unwrap(),
+                    updated_at: DateTime::parse_from_rfc3339("2021-06-25T19:07:33.155Z").unwrap(),
+                }
             }
         )
     }


### PR DESCRIPTION
This PR defines a `Timestamps` struct and adds timestamps to the `Connection` and `Organization` structs.