### PR TITLE
[Merged by Bors] - Add support for `rustls`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,11 +10,19 @@ edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[features]
+default = ["rustls-tls"]
+native-tls = ["reqwest/default-tls", "openssl"]
+rustls-tls = ["reqwest/rustls-tls", "ring", "pem"]
+
 [dependencies]
 async-trait = "0.1"
 chrono = { version = "0.4", features = ["serde"] }
+openssl = { version = "0.10", default-features = false, optional = true }
+pem = { version = "0.8", default-features = false, optional = true }
 querystring = "1.1"
-reqwest = { version = "0.11", features = ["json"] }
+reqwest = { version = "0.11", default-features = false, features = ["json"] }
+ring = { version = "0.16", default-features = false, optional = true }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 thiserror = "1.0"


### PR DESCRIPTION
This PR adds support for `rustls` instead of using the system's native TLS (usually `openssl`).

The following feature flags have been added to the crate:
- `native-tls` - This will have the SDK use native TLS
- `rustls-tls` - This will have the SDK use `rustls`

The `rustls-tls` feature flag is enabled by default.

Resolves SDK-497.