### PR TITLE
[Merged by Bors] - Add dedicated `Timestamp` type

### DIFF
--- a/src/core/types/timestamps.rs
+++ b/src/core/types/timestamps.rs
@@ -1,12 +1,49 @@
 use chrono::{DateTime, FixedOffset};
 use serde::{Deserialize, Serialize};
 
+/// A UTC timestamp.
+#[derive(Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct Timestamp(pub DateTime<FixedOffset>);
+
+impl TryFrom<String> for Timestamp {
+    type Error = chrono::ParseError;
+
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        Ok(Self(DateTime::parse_from_rfc3339(&value)?))
+    }
+}
+
+impl TryFrom<&str> for Timestamp {
+    type Error = chrono::ParseError;
+
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        Ok(Self(DateTime::parse_from_rfc3339(value)?))
+    }
+}
+
 /// The timestamps for an object.
 #[derive(Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct Timestamps {
     /// The timestamp indicating when the object was created.
-    pub created_at: DateTime<FixedOffset>,
+    pub created_at: Timestamp,
 
     /// The timestamp indicating when the object was last updated.
-    pub updated_at: DateTime<FixedOffset>,
+    pub updated_at: Timestamp,
+}
+
+#[cfg(test)]
+mod test {
+    use chrono::DateTime;
+
+    use super::Timestamp;
+
+    #[test]
+    fn it_parses_a_timestamp_from_an_iso_string() {
+        let iso_string = "2022-06-28T19:07:33.155Z";
+
+        assert_eq!(
+            Timestamp::try_from(iso_string),
+            DateTime::parse_from_rfc3339(iso_string).map(Timestamp)
+        )
+    }
 }

--- a/src/directory_sync/types/directory.rs
+++ b/src/directory_sync/types/directory.rs
@@ -80,9 +80,7 @@ mod test {
 
     use crate::directory_sync::DirectoryType;
     use crate::organizations::OrganizationId;
-    use crate::KnownOrUnknown;
-    use crate::Timestamps;
-    use chrono::DateTime;
+    use crate::{KnownOrUnknown, Timestamp, Timestamps};
 
     use super::{Directory, DirectoryId, DirectoryState};
 
@@ -113,8 +111,8 @@ mod test {
                 name: "Foo Corp".to_string(),
                 state: DirectoryState::Unlinked,
                 timestamps: Timestamps {
-                    created_at: DateTime::parse_from_rfc3339("2021-06-25T19:07:33.155Z").unwrap(),
-                    updated_at: DateTime::parse_from_rfc3339("2021-06-25T19:07:33.155Z").unwrap(),
+                    created_at: Timestamp::try_from("2021-06-25T19:07:33.155Z").unwrap(),
+                    updated_at: Timestamp::try_from("2021-06-25T19:07:33.155Z").unwrap(),
                 }
             }
         )

--- a/src/directory_sync/types/directory_group.rs
+++ b/src/directory_sync/types/directory_group.rs
@@ -52,11 +52,13 @@ pub struct DirectoryGroup {
 
 #[cfg(test)]
 mod test {
-    use super::{DirectoryGroup, DirectoryGroupId, DirectoryId};
-    use crate::{RawAttributes, Timestamps};
-    use chrono::DateTime;
-    use serde_json::{json, Value};
     use std::collections::HashMap;
+
+    use serde_json::{json, Value};
+
+    use crate::{RawAttributes, Timestamp, Timestamps};
+
+    use super::{DirectoryGroup, DirectoryGroupId, DirectoryId};
 
     #[test]
     fn it_deserializes_a_directory_group() {
@@ -86,8 +88,8 @@ mod test {
                 directory_id: DirectoryId::from("directory_01ECAZ4NV9QMV47GW873HDCX74"),
                 name: "Developers".to_string(),
                 timestamps: Timestamps {
-                    created_at: DateTime::parse_from_rfc3339("2021-06-25T19:07:33.155Z").unwrap(),
-                    updated_at: DateTime::parse_from_rfc3339("2021-06-25T19:07:33.155Z").unwrap(),
+                    created_at: Timestamp::try_from("2021-06-25T19:07:33.155Z").unwrap(),
+                    updated_at: Timestamp::try_from("2021-06-25T19:07:33.155Z").unwrap(),
                 },
                 raw_attributes: RawAttributes(expected_raw_attributes)
             }

--- a/src/directory_sync/types/directory_user.rs
+++ b/src/directory_sync/types/directory_user.rs
@@ -99,14 +99,14 @@ pub struct DirectoryUserEmail {
 mod test {
     use std::collections::HashMap;
 
-    use chrono::DateTime;
     use serde::Deserialize;
     use serde_json::{json, Value};
+
+    use crate::{KnownOrUnknown, RawAttributes, Timestamp, Timestamps};
 
     use super::{
         DirectoryId, DirectoryUser, DirectoryUserEmail, DirectoryUserId, DirectoryUserState,
     };
-    use crate::{KnownOrUnknown, RawAttributes, Timestamps};
 
     #[test]
     fn it_deserializes_a_directory_user() {
@@ -175,8 +175,8 @@ mod test {
                 custom_attributes: expected_custom_attributes,
                 raw_attributes: RawAttributes(expected_raw_attributes),
                 timestamps: Timestamps {
-                    created_at: DateTime::parse_from_rfc3339("2021-06-25T19:07:33.155Z").unwrap(),
-                    updated_at: DateTime::parse_from_rfc3339("2021-06-25T19:07:33.155Z").unwrap(),
+                    created_at: Timestamp::try_from("2021-06-25T19:07:33.155Z").unwrap(),
+                    updated_at: Timestamp::try_from("2021-06-25T19:07:33.155Z").unwrap(),
                 }
             }
         )

--- a/src/passwordless/types/passwordless_session.rs
+++ b/src/passwordless/types/passwordless_session.rs
@@ -1,7 +1,8 @@
 use std::fmt::Display;
 
-use chrono::{DateTime, FixedOffset};
 use serde::{Deserialize, Serialize};
+
+use crate::Timestamp;
 
 /// The ID of an [`PasswordlessSession`].
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
@@ -50,13 +51,14 @@ pub struct PasswordlessSession {
     pub r#type: PasswordlessSessionType,
 
     /// The timestamp indicating when the passwordless session will expire.
-    pub expires_at: DateTime<FixedOffset>,
+    pub expires_at: Timestamp,
 }
 
 #[cfg(test)]
 mod test {
-    use chrono::DateTime;
     use serde_json::json;
+
+    use crate::Timestamp;
 
     use super::{PasswordlessSession, PasswordlessSessionId, PasswordlessSessionType};
 
@@ -83,7 +85,7 @@ mod test {
                     link: "https://auth.workos.com/passwordless/4TeRexuejWCKs9rrFOIuLRYEr/confirm"
                         .to_string(),
                 },
-                expires_at: DateTime::parse_from_rfc3339("2020-08-13T05:50:00.000Z").unwrap()
+                expires_at: Timestamp::try_from("2020-08-13T05:50:00.000Z").unwrap()
             }
         )
     }

--- a/src/sso/types/connection.rs
+++ b/src/sso/types/connection.rs
@@ -65,12 +65,11 @@ pub struct Connection {
 
 #[cfg(test)]
 mod test {
-    use chrono::DateTime;
     use serde_json::json;
 
+    use crate::organizations::OrganizationId;
     use crate::sso::ConnectionType;
-    use crate::KnownOrUnknown;
-    use crate::{organizations::OrganizationId, Timestamps};
+    use crate::{KnownOrUnknown, Timestamp, Timestamps};
 
     use super::{Connection, ConnectionId, ConnectionState};
 
@@ -100,8 +99,8 @@ mod test {
                 name: "Foo Corp".to_string(),
                 state: ConnectionState::Active,
                 timestamps: Timestamps {
-                    created_at: DateTime::parse_from_rfc3339("2021-06-25T19:07:33.155Z").unwrap(),
-                    updated_at: DateTime::parse_from_rfc3339("2021-06-25T19:07:33.155Z").unwrap(),
+                    created_at: Timestamp::try_from("2021-06-25T19:07:33.155Z").unwrap(),
+                    updated_at: Timestamp::try_from("2021-06-25T19:07:33.155Z").unwrap(),
                 }
             }
         )


### PR DESCRIPTION
This PR adds a dedicated `Timestamp` type that we can use to codify some of the semantics around timestamps.

Resolves SDK-504.