### PR TITLE
[Merged by Bors] - Setup `rustdoc` for `main`

### DIFF
--- a/.github/workflows/rustdoc.yml
+++ b/.github/workflows/rustdoc.yml
@@ -2,7 +2,7 @@ name: rustdoc
 
 on:
   push:
-    branches: [main, setup-rustdoc-for-main]
+    branches: [main]
 
 jobs:
   deploy:
@@ -29,7 +29,7 @@ jobs:
 
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3
-        # if: ${{ github.ref == 'refs/heads/main' }}
+        if: ${{ github.ref == 'refs/heads/main' }}
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./target/doc

--- a/.github/workflows/rustdoc.yml
+++ b/.github/workflows/rustdoc.yml
@@ -2,7 +2,7 @@ name: rustdoc
 
 on:
   push:
-    branches: [main]
+    branches: [main, setup-rustdoc-for-main]
 
 jobs:
   deploy:
@@ -29,7 +29,7 @@ jobs:
 
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3
-        if: ${{ github.ref == 'refs/heads/main' }}
+        # if: ${{ github.ref == 'refs/heads/main' }}
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./target/doc

--- a/.github/workflows/rustdoc.yml
+++ b/.github/workflows/rustdoc.yml
@@ -2,7 +2,7 @@ name: rustdoc
 
 on:
   push:
-    branches: [main]
+    branches: [main, setup-rustdoc-for-main]
 
 jobs:
   deploy:
@@ -26,10 +26,11 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: doc
+          args: --no-deps
 
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3
-        if: ${{ github.ref == 'refs/heads/main' }}
+        # if: ${{ github.ref == 'refs/heads/main' }}
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./target/doc

--- a/.github/workflows/rustdoc.yml
+++ b/.github/workflows/rustdoc.yml
@@ -2,7 +2,7 @@ name: rustdoc
 
 on:
   push:
-    branches: [main]
+    branches: [main, setup-rustdoc-for-main]
 
 jobs:
   deploy:
@@ -30,7 +30,7 @@ jobs:
 
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3
-        if: ${{ github.ref == 'refs/heads/main' }}
+        # if: ${{ github.ref == 'refs/heads/main' }}
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./target/doc

--- a/.github/workflows/rustdoc.yml
+++ b/.github/workflows/rustdoc.yml
@@ -28,6 +28,10 @@ jobs:
           command: doc
           args: --no-deps
 
+      - name: Add index.html
+        run: echo "<meta http-equiv=\"refresh\" content=\"0; url=workos\">" > ./target/doc/index.html
+        shell: bash
+
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3
         # if: ${{ github.ref == 'refs/heads/main' }}

--- a/.github/workflows/rustdoc.yml
+++ b/.github/workflows/rustdoc.yml
@@ -1,0 +1,35 @@
+name: rustdoc
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Install Rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          profile: minimal
+          override: true
+          components: cargo
+
+      - name: cargo doc
+        uses: actions-rs/cargo@v1
+        with:
+          command: doc
+
+      - name: Deploy
+        uses: peaceiris/actions-gh-pages@v3
+        if: ${{ github.ref == 'refs/heads/main' }}
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./target/doc

--- a/.github/workflows/rustdoc.yml
+++ b/.github/workflows/rustdoc.yml
@@ -2,7 +2,7 @@ name: rustdoc
 
 on:
   push:
-    branches: [main, setup-rustdoc-for-main]
+    branches: [main]
 
 jobs:
   deploy:
@@ -34,7 +34,7 @@ jobs:
 
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3
-        # if: ${{ github.ref == 'refs/heads/main' }}
+        if: ${{ github.ref == 'refs/heads/main' }}
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./target/doc

--- a/.github/workflows/rustdoc.yml
+++ b/.github/workflows/rustdoc.yml
@@ -2,7 +2,7 @@ name: rustdoc
 
 on:
   push:
-    branches: [main, setup-rustdoc-for-main]
+    branches: [main]
 
 jobs:
   deploy:
@@ -30,7 +30,7 @@ jobs:
 
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3
-        # if: ${{ github.ref == 'refs/heads/main' }}
+        if: ${{ github.ref == 'refs/heads/main' }}
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./target/doc


### PR DESCRIPTION
This PR sets up `rustdoc` for the `main` branch so that we can view documentation for the unreleased changes.

Docs are available at [workos.github.io/workos-rust/workos](https://workos.github.io/workos-rust/workos/).

Resolves SDK-509.