### PR TITLE
[Merged by Bors] - Remove unused `DateTime` import

### DIFF
--- a/src/mfa/types/authentication_factor.rs
+++ b/src/mfa/types/authentication_factor.rs
@@ -68,7 +68,6 @@ pub enum AuthenticationFactorType {
 
 #[cfg(test)]
 mod test {
-    use chrono::DateTime;
     use serde_json::json;
 
     use crate::{Timestamp, Timestamps};


### PR DESCRIPTION
This PR removes an unused `chrono::DateTime` import.