### PR TITLE
[Merged by Bors] - Use `KnownOrUnknown` for `Connection.state`

### DIFF
--- a/src/sso/types/connection.rs
+++ b/src/sso/types/connection.rs
@@ -56,7 +56,7 @@ pub struct Connection {
     pub name: String,
 
     /// The state of the connection.
-    pub state: ConnectionState,
+    pub state: KnownOrUnknown<ConnectionState, String>,
 
     /// The timestamps for the connection.
     #[serde(flatten)]
@@ -97,7 +97,7 @@ mod test {
                 organization_id: Some(OrganizationId::from("org_01EHWNCE74X7JSDV0X3SZ3KJNY")),
                 r#type: KnownOrUnknown::Known(ConnectionType::GoogleOauth),
                 name: "Foo Corp".to_string(),
-                state: ConnectionState::Active,
+                state: KnownOrUnknown::Known(ConnectionState::Active),
                 timestamps: Timestamps {
                     created_at: Timestamp::try_from("2021-06-25T19:07:33.155Z").unwrap(),
                     updated_at: Timestamp::try_from("2021-06-25T19:07:33.155Z").unwrap(),

--- a/src/webhooks/types/events/connection_activated.rs
+++ b/src/webhooks/types/events/connection_activated.rs
@@ -56,7 +56,7 @@ mod test {
                     organization_id: Some(OrganizationId::from("org_01EHWNCE74X7JSDV0X3SZ3KJNY")),
                     r#type: KnownOrUnknown::Known(ConnectionType::OktaSaml),
                     name: "Foo Corp's Connection".to_string(),
-                    state: ConnectionState::Active,
+                    state: KnownOrUnknown::Known(ConnectionState::Active),
                     timestamps: Timestamps {
                         created_at: Timestamp::try_from("2021-06-25T19:07:33.155Z").unwrap(),
                         updated_at: Timestamp::try_from("2021-06-25T19:07:33.155Z").unwrap()

--- a/src/webhooks/types/events/connection_deactivated.rs
+++ b/src/webhooks/types/events/connection_deactivated.rs
@@ -59,7 +59,7 @@ mod test {
                         )),
                         r#type: KnownOrUnknown::Known(ConnectionType::OktaSaml),
                         name: "Foo Corp's Connection".to_string(),
-                        state: ConnectionState::Inactive,
+                        state: KnownOrUnknown::Known(ConnectionState::Inactive),
                         timestamps: Timestamps {
                             created_at: Timestamp::try_from("2021-06-25T19:07:33.155Z").unwrap(),
                             updated_at: Timestamp::try_from("2021-06-25T19:07:33.155Z").unwrap()


### PR DESCRIPTION
This PR updates the `state` field on `Connection`s to use `KnownOrUnknown` to support deserializing unknown values.

Resolves SDK-515.