### PR TITLE
[Merged by Bors] - Add `connection.deleted` webhook event

### DIFF
--- a/src/webhooks/types/events.rs
+++ b/src/webhooks/types/events.rs
@@ -1,5 +1,7 @@
 mod connection_activated;
 mod connection_deactivated;
+mod connection_deleted;
 
 pub use connection_activated::*;
 pub use connection_deactivated::*;
+pub use connection_deleted::*;

--- a/src/webhooks/types/events/connection_deleted.rs
+++ b/src/webhooks/types/events/connection_deleted.rs
@@ -47,7 +47,7 @@ mod test {
                     organization_id: Some(OrganizationId::from("org_01EHWNCE74X7JSDV0X3SZ3KJNY")),
                     r#type: KnownOrUnknown::Known(ConnectionType::OktaSaml),
                     name: "Foo Corp's Connection".to_string(),
-                    state: ConnectionState::Inactive,
+                    state: KnownOrUnknown::Known(ConnectionState::Inactive),
                     timestamps: Timestamps {
                         created_at: Timestamp::try_from("2021-06-25T19:07:33.155Z").unwrap(),
                         updated_at: Timestamp::try_from("2021-06-25T19:07:33.155Z").unwrap()

--- a/src/webhooks/types/events/connection_deleted.rs
+++ b/src/webhooks/types/events/connection_deleted.rs
@@ -1,0 +1,59 @@
+use serde::Deserialize;
+
+use crate::sso::Connection;
+
+/// [WorkOS Docs: `connection.activated` Webhook](https://workos.com/docs/reference/webhooks/connection#webhooks-sso.connection.activated)
+#[derive(Debug, PartialEq, Eq, Deserialize)]
+pub struct ConnectionDeletedWebhook(pub Connection);
+
+#[cfg(test)]
+mod test {
+    use serde_json::json;
+
+    use crate::organizations::OrganizationId;
+    use crate::sso::{ConnectionId, ConnectionState, ConnectionType};
+    use crate::webhooks::{Webhook, WebhookEvent, WebhookId};
+    use crate::{KnownOrUnknown, Timestamp, Timestamps};
+
+    use super::*;
+
+    #[test]
+    fn it_deserializes_a_connection_deleted_webhook() {
+        let webhook: Webhook = serde_json::from_str(
+            &json!({
+              "id": "wh_01G69A9MDSW8MM1XW5S0EHA0NV",
+              "event": "connection.deleted",
+              "data": {
+                "object": "connection",
+                "id": "conn_01EHWNC0FCBHZ3BJ7EGKYXK0E6",
+                "organization_id": "org_01EHWNCE74X7JSDV0X3SZ3KJNY",
+                "connection_type": "OktaSAML",
+                "name": "Foo Corp's Connection",
+                "state": "inactive",
+                "created_at": "2021-06-25T19:07:33.155Z",
+                "updated_at": "2021-06-25T19:07:33.155Z"
+              }
+            })
+            .to_string(),
+        )
+        .unwrap();
+
+        assert_eq!(
+            webhook,
+            Webhook {
+                id: WebhookId::from("wh_01G69A9MDSW8MM1XW5S0EHA0NV"),
+                event: WebhookEvent::ConnectionDeleted(ConnectionDeletedWebhook(Connection {
+                    id: ConnectionId::from("conn_01EHWNC0FCBHZ3BJ7EGKYXK0E6"),
+                    organization_id: Some(OrganizationId::from("org_01EHWNCE74X7JSDV0X3SZ3KJNY")),
+                    r#type: KnownOrUnknown::Known(ConnectionType::OktaSaml),
+                    name: "Foo Corp's Connection".to_string(),
+                    state: ConnectionState::Inactive,
+                    timestamps: Timestamps {
+                        created_at: Timestamp::try_from("2021-06-25T19:07:33.155Z").unwrap(),
+                        updated_at: Timestamp::try_from("2021-06-25T19:07:33.155Z").unwrap()
+                    }
+                }))
+            }
+        )
+    }
+}

--- a/src/webhooks/types/webhook_event.rs
+++ b/src/webhooks/types/webhook_event.rs
@@ -13,4 +13,8 @@ pub enum WebhookEvent {
     /// [WorkOS Docs: `connection.deactivated` Webhook](https://workos.com/docs/reference/webhooks/connection#webhooks-sso.connection.deactivated)
     #[serde(rename = "connection.deactivated")]
     ConnectionDeactivated(ConnectionDeactivatedWebhook),
+
+    /// [WorkOS Docs: `connection.deleted` Webhook](https://workos.com/docs/reference/webhooks/connection#webhooks-sso.connection.deleted)
+    #[serde(rename = "connection.deleted")]
+    ConnectionDeleted(ConnectionDeletedWebhook),
 }


### PR DESCRIPTION
This PR adds the `connection.deleted` webhook event.

Resolves SDK-516.