### PR TITLE
[Merged by Bors] - Rename `Options` to `Params`

### DIFF
--- a/src/admin_portal/operations/generate_portal_link.rs
+++ b/src/admin_portal/operations/generate_portal_link.rs
@@ -33,9 +33,9 @@ pub enum AdminPortalTarget {
     },
 }
 
-/// The options for [`GeneratePortalLink`].
+/// The parameters for [`GeneratePortalLink`].
 #[derive(Debug, Serialize)]
-pub struct GeneratePortalLinkOptions<'a> {
+pub struct GeneratePortalLinkParams<'a> {
     /// The target of the Admin Portal.
     #[serde(flatten)]
     pub target: &'a AdminPortalTarget,
@@ -65,7 +65,7 @@ pub trait GeneratePortalLink {
     /// [WorkOS Docs: Generate a Portal Link](https://workos.com/docs/reference/admin-portal/portal-link/generate)
     async fn generate_portal_link(
         &self,
-        options: &GeneratePortalLinkOptions<'_>,
+        params: &GeneratePortalLinkParams<'_>,
     ) -> WorkOsResult<GeneratePortalLinkResponse, GeneratePortalLinkError>;
 }
 
@@ -73,7 +73,7 @@ pub trait GeneratePortalLink {
 impl<'a> GeneratePortalLink for AdminPortal<'a> {
     async fn generate_portal_link(
         &self,
-        options: &GeneratePortalLinkOptions<'_>,
+        params: &GeneratePortalLinkParams<'_>,
     ) -> WorkOsResult<GeneratePortalLinkResponse, GeneratePortalLinkError> {
         let url = self.workos.base_url().join("/portal/generate_link")?;
         let response = self
@@ -81,7 +81,7 @@ impl<'a> GeneratePortalLink for AdminPortal<'a> {
             .client()
             .post(url)
             .bearer_auth(self.workos.key())
-            .json(&options)
+            .json(&params)
             .send()
             .await?;
 
@@ -130,7 +130,7 @@ mod test {
 
         let GeneratePortalLinkResponse { link } = workos
             .admin_portal()
-            .generate_portal_link(&GeneratePortalLinkOptions {
+            .generate_portal_link(&GeneratePortalLinkParams {
                 target: &AdminPortalTarget::Organization {
                     organization_id: OrganizationId::from("org_01EHZNVPK3SFK441A1RGBFSHRT"),
                     intent: AdminPortalIntent::Sso,

--- a/src/core/types.rs
+++ b/src/core/types.rs
@@ -1,13 +1,13 @@
 mod api_key;
 mod paginated_list;
-mod pagination_options;
+mod pagination_params;
 mod raw_attributes;
 mod timestamps;
 mod url_encodable_vec;
 
 pub use api_key::*;
 pub use paginated_list::*;
-pub use pagination_options::*;
+pub use pagination_params::*;
 pub use raw_attributes::*;
 pub use timestamps::*;
 pub(crate) use url_encodable_vec::*;

--- a/src/core/types/pagination_params.rs
+++ b/src/core/types/pagination_params.rs
@@ -1,8 +1,8 @@
 use serde::Serialize;
 
-/// The options used to control pagination for a given paginated endpoint.
+/// The parameters used to control pagination for a given paginated endpoint.
 #[derive(Debug, Serialize)]
-pub struct PaginationOptions<'a> {
+pub struct PaginationParams<'a> {
     /// The order in which records should be paginated.
     pub order: &'a PaginationOrder,
 
@@ -13,7 +13,7 @@ pub struct PaginationOptions<'a> {
     pub before: &'a Option<String>,
 }
 
-impl<'a> Default for PaginationOptions<'a> {
+impl<'a> Default for PaginationParams<'a> {
     fn default() -> Self {
         Self {
             order: &PaginationOrder::DEFAULT,

--- a/src/directory_sync/operations/delete_directory.rs
+++ b/src/directory_sync/operations/delete_directory.rs
@@ -6,9 +6,9 @@ use thiserror::Error;
 use crate::directory_sync::{DirectoryId, DirectorySync};
 use crate::{WorkOsError, WorkOsResult};
 
-/// The options for [`DeleteDirectory`].
+/// The parameters for [`DeleteDirectory`].
 #[derive(Debug, Serialize)]
-pub struct DeleteDirectoryOptions<'a> {
+pub struct DeleteDirectoryParams<'a> {
     /// The ID of the directory to delete.
     pub directory_id: &'a DirectoryId,
 }
@@ -31,7 +31,7 @@ pub trait DeleteDirectory {
     /// [WorkOS Docs: Delete a Directory](https://workos.com/docs/reference/directory-sync/directory/delete)
     async fn delete_directory(
         &self,
-        options: &DeleteDirectoryOptions<'_>,
+        params: &DeleteDirectoryParams<'_>,
     ) -> WorkOsResult<(), DeleteDirectoryError>;
 }
 
@@ -39,12 +39,12 @@ pub trait DeleteDirectory {
 impl<'a> DeleteDirectory for DirectorySync<'a> {
     async fn delete_directory(
         &self,
-        options: &DeleteDirectoryOptions<'_>,
+        params: &DeleteDirectoryParams<'_>,
     ) -> WorkOsResult<(), DeleteDirectoryError> {
         let url = self
             .workos
             .base_url()
-            .join(&format!("/directories/{id}", id = options.directory_id))?;
+            .join(&format!("/directories/{id}", id = params.directory_id))?;
         let response = self
             .workos
             .client()
@@ -91,7 +91,7 @@ mod test {
 
         let result = workos
             .directory_sync()
-            .delete_directory(&DeleteDirectoryOptions {
+            .delete_directory(&DeleteDirectoryParams {
                 directory_id: &DirectoryId::from("directory_01ECAZ4NV9QMV47GW873HDCX74"),
             })
             .await;

--- a/src/directory_sync/operations/list_directories.rs
+++ b/src/directory_sync/operations/list_directories.rs
@@ -15,7 +15,7 @@ pub struct ListDirectoriesParams<'a> {
     /// Searchable text to match against Directory names.
     pub search: Option<&'a String>,
 
-    /// The pagination options to use when listing directories.
+    /// The pagination parameters to use when listing directories.
     #[serde(flatten)]
     pub pagination: PaginationParams<'a>,
 

--- a/src/directory_sync/operations/list_directories.rs
+++ b/src/directory_sync/operations/list_directories.rs
@@ -4,11 +4,11 @@ use serde::Serialize;
 
 use crate::directory_sync::{Directory, DirectorySync, DirectoryType};
 use crate::organizations::OrganizationId;
-use crate::{KnownOrUnknown, PaginatedList, PaginationOptions, WorkOsError, WorkOsResult};
+use crate::{KnownOrUnknown, PaginatedList, PaginationParams, WorkOsError, WorkOsResult};
 
-/// The options for [`ListDirectories`].
+/// The parameters for [`ListDirectories`].
 #[derive(Debug, Serialize)]
-pub struct ListDirectoriesOptions<'a> {
+pub struct ListDirectoriesParams<'a> {
     /// The domain of a directory.
     pub domain: Option<&'a String>,
 
@@ -17,7 +17,7 @@ pub struct ListDirectoriesOptions<'a> {
 
     /// The pagination options to use when listing directories.
     #[serde(flatten)]
-    pub pagination: PaginationOptions<'a>,
+    pub pagination: PaginationParams<'a>,
 
     /// The ID of the organization to list directories for.
     pub organization_id: Option<&'a OrganizationId>,
@@ -27,10 +27,10 @@ pub struct ListDirectoriesOptions<'a> {
     pub r#type: &'a Option<KnownOrUnknown<DirectoryType, String>>,
 }
 
-impl<'a> Default for ListDirectoriesOptions<'a> {
+impl<'a> Default for ListDirectoriesParams<'a> {
     fn default() -> Self {
         Self {
-            pagination: PaginationOptions::default(),
+            pagination: PaginationParams::default(),
             organization_id: None,
             r#type: &None,
             domain: None,
@@ -47,7 +47,7 @@ pub trait ListDirectories {
     /// [WorkOS Docs: List Directories](https://workos.com/docs/reference/directory-sync/directory/list)
     async fn list_directories(
         &self,
-        options: &ListDirectoriesOptions<'_>,
+        params: &ListDirectoriesParams<'_>,
     ) -> WorkOsResult<PaginatedList<Directory>, ()>;
 }
 
@@ -55,14 +55,14 @@ pub trait ListDirectories {
 impl<'a> ListDirectories for DirectorySync<'a> {
     async fn list_directories(
         &self,
-        options: &ListDirectoriesOptions<'_>,
+        params: &ListDirectoriesParams<'_>,
     ) -> WorkOsResult<PaginatedList<Directory>, ()> {
         let url = self.workos.base_url().join("/directories")?;
         let response = self
             .workos
             .client()
             .get(url)
-            .query(&options)
+            .query(&params)
             .bearer_auth(self.workos.key())
             .send()
             .await?;
@@ -187,7 +187,7 @@ mod test {
 
         let paginated_list = workos
             .directory_sync()
-            .list_directories(&ListDirectoriesOptions {
+            .list_directories(&ListDirectoriesParams {
                 r#type: &Some(KnownOrUnknown::Known(DirectoryType::GoogleWorkspace)),
                 ..Default::default()
             })

--- a/src/directory_sync/operations/list_directory_groups.rs
+++ b/src/directory_sync/operations/list_directory_groups.rs
@@ -25,7 +25,7 @@ pub enum DirectoryGroupsFilter<'a> {
 /// The parameters for [`ListDirectoryGroups`].
 #[derive(Debug, Serialize)]
 pub struct ListDirectoryGroupsParams<'a> {
-    /// The pagination options to use when listing directory groups.
+    /// The pagination parameters to use when listing directory groups.
     #[serde(flatten)]
     pub pagination: PaginationParams<'a>,
 

--- a/src/directory_sync/operations/list_directory_groups.rs
+++ b/src/directory_sync/operations/list_directory_groups.rs
@@ -3,7 +3,7 @@ use reqwest::StatusCode;
 use serde::Serialize;
 
 use crate::directory_sync::{DirectoryGroup, DirectoryId, DirectorySync, DirectoryUserId};
-use crate::{PaginatedList, PaginationOptions, WorkOsError, WorkOsResult};
+use crate::{PaginatedList, PaginationParams, WorkOsError, WorkOsResult};
 
 /// A filter for [`ListDirectoryGroups`].
 #[derive(Debug, Serialize)]
@@ -22,12 +22,12 @@ pub enum DirectoryGroupsFilter<'a> {
     },
 }
 
-/// The options for [`ListDirectoryGroups`].
+/// The parameters for [`ListDirectoryGroups`].
 #[derive(Debug, Serialize)]
-pub struct ListDirectoryGroupsOptions<'a> {
+pub struct ListDirectoryGroupsParams<'a> {
     /// The pagination options to use when listing directory groups.
     #[serde(flatten)]
-    pub pagination: PaginationOptions<'a>,
+    pub pagination: PaginationParams<'a>,
 
     /// The filter to use when listing directory groupss.
     #[serde(flatten)]
@@ -42,7 +42,7 @@ pub trait ListDirectoryGroups {
     /// [WorkOS Docs: List Directory Groups](https://workos.com/docs/reference/directory-sync/group/list)
     async fn list_directory_groups(
         &self,
-        options: &ListDirectoryGroupsOptions<'_>,
+        params: &ListDirectoryGroupsParams<'_>,
     ) -> WorkOsResult<PaginatedList<DirectoryGroup>, ()>;
 }
 
@@ -50,14 +50,14 @@ pub trait ListDirectoryGroups {
 impl<'a> ListDirectoryGroups for DirectorySync<'a> {
     async fn list_directory_groups(
         &self,
-        options: &ListDirectoryGroupsOptions<'_>,
+        params: &ListDirectoryGroupsParams<'_>,
     ) -> WorkOsResult<PaginatedList<DirectoryGroup>, ()> {
         let url = self.workos.base_url().join("/directory_groups")?;
         let response = self
             .workos
             .client()
             .get(url)
-            .query(&options)
+            .query(&params)
             .bearer_auth(self.workos.key())
             .send()
             .await?;
@@ -127,7 +127,7 @@ mod test {
 
         let paginated_list = workos
             .directory_sync()
-            .list_directory_groups(&ListDirectoryGroupsOptions {
+            .list_directory_groups(&ListDirectoryGroupsParams {
                 pagination: Default::default(),
                 filter: DirectoryGroupsFilter::Directory {
                     directory: &DirectoryId::from("directory_01ECAZ4NV9QMV47GW873HDCX74"),
@@ -199,7 +199,7 @@ mod test {
 
         let paginated_list = workos
             .directory_sync()
-            .list_directory_groups(&ListDirectoryGroupsOptions {
+            .list_directory_groups(&ListDirectoryGroupsParams {
                 pagination: Default::default(),
                 filter: DirectoryGroupsFilter::User {
                     user: &DirectoryUserId::from("directory_user_01FYVX377G1S69ASY580WK6WVN"),

--- a/src/directory_sync/operations/list_directory_users.rs
+++ b/src/directory_sync/operations/list_directory_users.rs
@@ -25,7 +25,7 @@ pub enum DirectoryUsersFilter<'a> {
 /// The parameters for [`ListDirectoryUsers`].
 #[derive(Debug, Serialize)]
 pub struct ListDirectoryUsersParams<'a> {
-    /// The pagination options to use when listing directory users.
+    /// The pagination parameters to use when listing directory users.
     #[serde(flatten)]
     pub pagination: PaginationParams<'a>,
 

--- a/src/directory_sync/operations/list_directory_users.rs
+++ b/src/directory_sync/operations/list_directory_users.rs
@@ -3,7 +3,7 @@ use reqwest::StatusCode;
 use serde::Serialize;
 
 use crate::directory_sync::{DirectoryGroupId, DirectoryId, DirectorySync, DirectoryUser};
-use crate::{PaginatedList, PaginationOptions, WorkOsError, WorkOsResult};
+use crate::{PaginatedList, PaginationParams, WorkOsError, WorkOsResult};
 
 /// A filter for [`ListDirectoryUsers`].
 #[derive(Debug, Serialize)]
@@ -22,12 +22,12 @@ pub enum DirectoryUsersFilter<'a> {
     },
 }
 
-/// The options for [`ListDirectoryUsers`].
+/// The parameters for [`ListDirectoryUsers`].
 #[derive(Debug, Serialize)]
-pub struct ListDirectoryUsersOptions<'a> {
+pub struct ListDirectoryUsersParams<'a> {
     /// The pagination options to use when listing directory users.
     #[serde(flatten)]
-    pub pagination: PaginationOptions<'a>,
+    pub pagination: PaginationParams<'a>,
 
     /// The filter to use when listing directory users.
     #[serde(flatten)]
@@ -42,7 +42,7 @@ pub trait ListDirectoryUsers {
     /// [WorkOS Docs: List Directory Users](https://workos.com/docs/reference/directory-sync/user/list)
     async fn list_directory_users(
         &self,
-        options: &ListDirectoryUsersOptions<'_>,
+        params: &ListDirectoryUsersParams<'_>,
     ) -> WorkOsResult<PaginatedList<DirectoryUser>, ()>;
 }
 
@@ -50,14 +50,14 @@ pub trait ListDirectoryUsers {
 impl<'a> ListDirectoryUsers for DirectorySync<'a> {
     async fn list_directory_users(
         &self,
-        options: &ListDirectoryUsersOptions<'_>,
+        params: &ListDirectoryUsersParams<'_>,
     ) -> WorkOsResult<PaginatedList<DirectoryUser>, ()> {
         let url = self.workos.base_url().join("/directory_users")?;
         let response = self
             .workos
             .client()
             .get(url)
-            .query(&options)
+            .query(&params)
             .bearer_auth(self.workos.key())
             .send()
             .await?;
@@ -184,7 +184,7 @@ mod test {
 
         let paginated_list = workos
             .directory_sync()
-            .list_directory_users(&ListDirectoryUsersOptions {
+            .list_directory_users(&ListDirectoryUsersParams {
                 pagination: Default::default(),
                 filter: DirectoryUsersFilter::Directory {
                     directory: &DirectoryId::from("directory_01ECAZ4NV9QMV47GW873HDCX74"),
@@ -302,7 +302,7 @@ mod test {
 
         let paginated_list = workos
             .directory_sync()
-            .list_directory_users(&ListDirectoryUsersOptions {
+            .list_directory_users(&ListDirectoryUsersParams {
                 pagination: Default::default(),
                 filter: DirectoryUsersFilter::Group {
                     group: &DirectoryGroupId::from("directory_group_01E64QTDNS0EGJ0FMCVY9BWGZT"),

--- a/src/mfa/operations/challenge_factor.rs
+++ b/src/mfa/operations/challenge_factor.rs
@@ -24,9 +24,9 @@ pub enum ChallengeAuthenticationFactorType<'a> {
     },
 }
 
-/// The options for [`ChallengeFactor`].
+/// The parameters for [`ChallengeFactor`].
 #[derive(Debug, Serialize)]
-pub struct ChallengeFactorOptions<'a> {
+pub struct ChallengeFactorParams<'a> {
     /// The ID of the authentication factor to challenge.
     pub authentication_factor_id: &'a AuthenticationFactorId,
 
@@ -47,7 +47,7 @@ pub trait ChallengeFactor {
     /// [WorkOS Docs: Challenge Factor](https://workos.com/docs/reference/mfa/challenge-factor)
     async fn challenge_factor(
         &self,
-        options: &ChallengeFactorOptions<'_>,
+        params: &ChallengeFactorParams<'_>,
     ) -> WorkOsResult<AuthenticationChallenge, ChallengeFactorError>;
 }
 
@@ -55,7 +55,7 @@ pub trait ChallengeFactor {
 impl<'a> ChallengeFactor for Mfa<'a> {
     async fn challenge_factor(
         &self,
-        options: &ChallengeFactorOptions<'_>,
+        params: &ChallengeFactorParams<'_>,
     ) -> WorkOsResult<AuthenticationChallenge, ChallengeFactorError> {
         let url = self.workos.base_url().join("/auth/factors/challenge")?;
         let response = self
@@ -63,7 +63,7 @@ impl<'a> ChallengeFactor for Mfa<'a> {
             .client()
             .post(url)
             .bearer_auth(self.workos.key())
-            .json(&options)
+            .json(&params)
             .send()
             .await?;
 
@@ -120,7 +120,7 @@ mod test {
 
         let challenge = workos
             .mfa()
-            .challenge_factor(&ChallengeFactorOptions {
+            .challenge_factor(&ChallengeFactorParams {
                 authentication_factor_id: &AuthenticationFactorId::from(
                     "auth_factor_01FVYZ5QM8N98T9ME5BCB2BBMJ",
                 ),
@@ -161,7 +161,7 @@ mod test {
 
         let challenge = workos
             .mfa()
-            .challenge_factor(&ChallengeFactorOptions {
+            .challenge_factor(&ChallengeFactorParams {
                 authentication_factor_id: &AuthenticationFactorId::from(
                     "auth_factor_01FVYZ5QM8N98T9ME5BCB2BBMJ",
                 ),

--- a/src/mfa/operations/verify_factor.rs
+++ b/src/mfa/operations/verify_factor.rs
@@ -17,9 +17,9 @@ pub struct VerifyFactorResponse {
     pub is_valid: bool,
 }
 
-/// The options for [`VerifyFactor`].
+/// The parameters for [`VerifyFactor`].
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Serialize)]
-pub struct VerifyFactorOptions<'a> {
+pub struct VerifyFactorParams<'a> {
     /// The ID of the authentication factor to verify.
     pub authentication_challenge_id: &'a AuthenticationChallengeId,
 
@@ -39,7 +39,7 @@ pub trait VerifyFactor {
     /// [WorkOS Docs: Verify Factor](https://workos.com/docs/reference/mfa/verify-factor)
     async fn verify_factor(
         &self,
-        options: &VerifyFactorOptions<'_>,
+        params: &VerifyFactorParams<'_>,
     ) -> WorkOsResult<VerifyFactorResponse, VerifyFactorError>;
 }
 
@@ -47,7 +47,7 @@ pub trait VerifyFactor {
 impl<'a> VerifyFactor for Mfa<'a> {
     async fn verify_factor(
         &self,
-        options: &VerifyFactorOptions<'_>,
+        params: &VerifyFactorParams<'_>,
     ) -> WorkOsResult<VerifyFactorResponse, VerifyFactorError> {
         let url = self.workos.base_url().join("/auth/factors/verify")?;
         let response = self
@@ -55,7 +55,7 @@ impl<'a> VerifyFactor for Mfa<'a> {
             .client()
             .post(url)
             .bearer_auth(self.workos.key())
-            .json(&options)
+            .json(&params)
             .send()
             .await?;
 
@@ -117,7 +117,7 @@ mod test {
 
         let verify = workos
             .mfa()
-            .verify_factor(&VerifyFactorOptions {
+            .verify_factor(&VerifyFactorParams {
                 authentication_challenge_id: &AuthenticationChallengeId::from(
                     "auth_challenge_01FVYZWQTZQ5VB6BC5MPG2EYC5",
                 ),

--- a/src/organizations/operations/create_organization.rs
+++ b/src/organizations/operations/create_organization.rs
@@ -8,9 +8,9 @@ use thiserror::Error;
 use crate::organizations::{Organization, Organizations};
 use crate::{WorkOsError, WorkOsResult};
 
-/// The options for [`CreateOrganization`].
+/// The parameters for [`CreateOrganization`].
 #[derive(Debug, Serialize)]
-pub struct CreateOrganizationOptions<'a> {
+pub struct CreateOrganizationParams<'a> {
     /// The name of the organization.
     pub name: &'a str,
 
@@ -46,7 +46,7 @@ pub trait CreateOrganization {
     /// [WorkOS Docs: Create an Organization](https://workos.com/docs/reference/organization/create)
     async fn create_organization(
         &self,
-        options: &CreateOrganizationOptions<'_>,
+        params: &CreateOrganizationParams<'_>,
     ) -> WorkOsResult<Organization, CreateOrganizationError>;
 }
 
@@ -54,7 +54,7 @@ pub trait CreateOrganization {
 impl<'a> CreateOrganization for Organizations<'a> {
     async fn create_organization(
         &self,
-        options: &CreateOrganizationOptions<'_>,
+        params: &CreateOrganizationParams<'_>,
     ) -> WorkOsResult<Organization, CreateOrganizationError> {
         let url = self.workos.base_url().join("/organizations")?;
         let response = self
@@ -62,7 +62,7 @@ impl<'a> CreateOrganization for Organizations<'a> {
             .client()
             .post(url)
             .bearer_auth(self.workos.key())
-            .json(&options)
+            .json(&params)
             .send()
             .await?;
 
@@ -122,7 +122,7 @@ mod test {
 
         let organization = workos
             .organizations()
-            .create_organization(&CreateOrganizationOptions {
+            .create_organization(&CreateOrganizationParams {
                 name: "Foo Corp",
                 allow_profiles_outside_organization: Some(&false),
                 domains: HashSet::from(["foo-corp.com"]),

--- a/src/organizations/operations/delete_organization.rs
+++ b/src/organizations/operations/delete_organization.rs
@@ -6,9 +6,9 @@ use thiserror::Error;
 use crate::organizations::{OrganizationId, Organizations};
 use crate::{WorkOsError, WorkOsResult};
 
-/// The options for [`DeleteOrganization`].
+/// The parameters for [`DeleteOrganization`].
 #[derive(Debug, Serialize)]
-pub struct DeleteOrganizationOptions<'a> {
+pub struct DeleteOrganizationParams<'a> {
     /// The ID of the organization.
     pub organization_id: &'a OrganizationId,
 }
@@ -31,7 +31,7 @@ pub trait DeleteOrganization {
     /// [WorkOS Docs: Delete an Organization](https://workos.com/docs/reference/organization/delete)
     async fn delete_organization(
         &self,
-        options: &DeleteOrganizationOptions<'_>,
+        params: &DeleteOrganizationParams<'_>,
     ) -> WorkOsResult<(), DeleteOrganizationError>;
 }
 
@@ -39,12 +39,12 @@ pub trait DeleteOrganization {
 impl<'a> DeleteOrganization for Organizations<'a> {
     async fn delete_organization(
         &self,
-        options: &DeleteOrganizationOptions<'_>,
+        params: &DeleteOrganizationParams<'_>,
     ) -> WorkOsResult<(), DeleteOrganizationError> {
-        let url = self.workos.base_url().join(&format!(
-            "/organizations/{id}",
-            id = options.organization_id
-        ))?;
+        let url = self
+            .workos
+            .base_url()
+            .join(&format!("/organizations/{id}", id = params.organization_id))?;
         let response = self
             .workos
             .client()
@@ -86,7 +86,7 @@ mod test {
 
         let result = workos
             .organizations()
-            .delete_organization(&DeleteOrganizationOptions {
+            .delete_organization(&DeleteOrganizationParams {
                 organization_id: &OrganizationId::from("org_01EHZNVPK3SFK441A1RGBFSHRT"),
             })
             .await;

--- a/src/organizations/operations/list_organizations.rs
+++ b/src/organizations/operations/list_organizations.rs
@@ -4,7 +4,7 @@ use serde::Serialize;
 use thiserror::Error;
 
 use crate::organizations::{Organization, Organizations};
-use crate::{PaginatedList, PaginationOptions, UrlEncodableVec, WorkOsError, WorkOsResult};
+use crate::{PaginatedList, PaginationParams, UrlEncodableVec, WorkOsError, WorkOsResult};
 
 /// The domains to filter the organizations by.
 #[derive(Debug, Serialize)]
@@ -18,20 +18,20 @@ impl<'a> From<Vec<&'a str>> for DomainFilters<'a> {
 
 /// Parameters for the [`ListOrganizations`] function.
 #[derive(Debug, Serialize)]
-pub struct ListOrganizationsOptions<'a> {
+pub struct ListOrganizationsParams<'a> {
     /// The pagination options to use when listing organizations.
     #[serde(flatten)]
-    pub pagination: PaginationOptions<'a>,
+    pub pagination: PaginationParams<'a>,
 
     /// The domains of Organizations to be listed.
     #[serde(rename = "domains[]")]
     pub domains: Option<DomainFilters<'a>>,
 }
 
-impl<'a> Default for ListOrganizationsOptions<'a> {
+impl<'a> Default for ListOrganizationsParams<'a> {
     fn default() -> Self {
         Self {
-            pagination: PaginationOptions::default(),
+            pagination: PaginationParams::default(),
             domains: None,
         }
     }
@@ -55,7 +55,7 @@ pub trait ListOrganizations {
     /// [WorkOS Docs: List Organizations](https://workos.com/docs/reference/organization/list)
     async fn list_organizations(
         &self,
-        options: &ListOrganizationsOptions<'_>,
+        params: &ListOrganizationsParams<'_>,
     ) -> WorkOsResult<PaginatedList<Organization>, ()>;
 }
 
@@ -63,14 +63,14 @@ pub trait ListOrganizations {
 impl<'a> ListOrganizations for Organizations<'a> {
     async fn list_organizations(
         &self,
-        options: &ListOrganizationsOptions<'_>,
+        params: &ListOrganizationsParams<'_>,
     ) -> WorkOsResult<PaginatedList<Organization>, ()> {
         let url = self.workos.base_url().join("/organizations")?;
         let response = self
             .workos
             .client()
             .get(url)
-            .query(&options)
+            .query(&params)
             .bearer_auth(self.workos.key())
             .send()
             .await?;
@@ -200,7 +200,7 @@ mod test {
 
         let paginated_list = workos
             .organizations()
-            .list_organizations(&ListOrganizationsOptions {
+            .list_organizations(&ListOrganizationsParams {
                 domains: Some(vec!["foo-corp.com"].into()),
                 ..Default::default()
             })

--- a/src/organizations/operations/list_organizations.rs
+++ b/src/organizations/operations/list_organizations.rs
@@ -19,7 +19,7 @@ impl<'a> From<Vec<&'a str>> for DomainFilters<'a> {
 /// Parameters for the [`ListOrganizations`] function.
 #[derive(Debug, Serialize)]
 pub struct ListOrganizationsParams<'a> {
-    /// The pagination options to use when listing organizations.
+    /// The pagination parameters to use when listing organizations.
     #[serde(flatten)]
     pub pagination: PaginationParams<'a>,
 

--- a/src/organizations/operations/update_organization.rs
+++ b/src/organizations/operations/update_organization.rs
@@ -8,9 +8,9 @@ use thiserror::Error;
 use crate::organizations::{Organization, OrganizationId, Organizations};
 use crate::{WorkOsError, WorkOsResult};
 
-/// The options for [`UpdateOrganization`].
+/// The parameters for [`UpdateOrganization`].
 #[derive(Debug, Serialize)]
-pub struct UpdateOrganizationOptions<'a> {
+pub struct UpdateOrganizationParams<'a> {
     /// The ID of the organization passed in the URL.
     #[serde(skip_serializing)]
     pub organization_id: &'a OrganizationId,
@@ -50,7 +50,7 @@ pub trait UpdateOrganization {
     /// [WorkOS Docs: Update an Organization](https://workos.com/docs/reference/organization/update)
     async fn update_organization(
         &self,
-        options: &UpdateOrganizationOptions<'_>,
+        params: &UpdateOrganizationParams<'_>,
     ) -> WorkOsResult<Organization, UpdateOrganizationError>;
 }
 
@@ -58,18 +58,18 @@ pub trait UpdateOrganization {
 impl<'a> UpdateOrganization for Organizations<'a> {
     async fn update_organization(
         &self,
-        options: &UpdateOrganizationOptions<'_>,
+        params: &UpdateOrganizationParams<'_>,
     ) -> WorkOsResult<Organization, UpdateOrganizationError> {
-        let url = self.workos.base_url().join(&format!(
-            "/organizations/{id}",
-            id = options.organization_id
-        ))?;
+        let url = self
+            .workos
+            .base_url()
+            .join(&format!("/organizations/{id}", id = params.organization_id))?;
         let response = self
             .workos
             .client()
             .put(url)
             .bearer_auth(self.workos.key())
-            .json(&options)
+            .json(&params)
             .send()
             .await?;
 
@@ -129,7 +129,7 @@ mod test {
 
         let organization = workos
             .organizations()
-            .update_organization(&UpdateOrganizationOptions {
+            .update_organization(&UpdateOrganizationParams {
                 organization_id: &OrganizationId::from("org_01EHZNVPK3SFK441A1RGBFSHRT"),
                 name: Some("Foo Corp"),
                 allow_profiles_outside_organization: Some(&false),

--- a/src/passwordless/operations/create_passwordless_session.rs
+++ b/src/passwordless/operations/create_passwordless_session.rs
@@ -17,9 +17,9 @@ pub enum CreatePasswordlessSessionType<'a> {
     },
 }
 
-/// The options for [`CreatePasswordlessSession`].
+/// The parameters for [`CreatePasswordlessSession`].
 #[derive(Debug, Serialize)]
-pub struct CreatePasswordlessSessionOptions<'a> {
+pub struct CreatePasswordlessSessionParams<'a> {
     /// The type of passwordless session to create.
     #[serde(flatten)]
     pub r#type: CreatePasswordlessSessionType<'a>,
@@ -47,7 +47,7 @@ pub trait CreatePasswordlessSession {
     /// [WorkOS Docs: Create a Passwordless Session](https://workos.com/docs/reference/magic-link/passwordless-session/create-session)
     async fn create_passwordless_session(
         &self,
-        options: &CreatePasswordlessSessionOptions<'_>,
+        params: &CreatePasswordlessSessionParams<'_>,
     ) -> WorkOsResult<PasswordlessSession, CreatePasswordlessSessionError>;
 }
 
@@ -55,7 +55,7 @@ pub trait CreatePasswordlessSession {
 impl<'a> CreatePasswordlessSession for Passwordless<'a> {
     async fn create_passwordless_session(
         &self,
-        options: &CreatePasswordlessSessionOptions<'_>,
+        params: &CreatePasswordlessSessionParams<'_>,
     ) -> WorkOsResult<PasswordlessSession, CreatePasswordlessSessionError> {
         let url = self.workos.base_url().join("/passwordless/sessions")?;
         let response = self
@@ -63,7 +63,7 @@ impl<'a> CreatePasswordlessSession for Passwordless<'a> {
             .client()
             .post(url)
             .bearer_auth(self.workos.key())
-            .json(&options)
+            .json(&params)
             .send()
             .await?;
 
@@ -117,7 +117,7 @@ mod test {
 
         let passwordless_session = workos
             .passwordless()
-            .create_passwordless_session(&CreatePasswordlessSessionOptions {
+            .create_passwordless_session(&CreatePasswordlessSessionParams {
                 r#type: CreatePasswordlessSessionType::MagicLink {
                     email: "marcelina@foo-corp.com",
                 },

--- a/src/passwordless/operations/send_passwordless_session.rs
+++ b/src/passwordless/operations/send_passwordless_session.rs
@@ -5,9 +5,9 @@ use serde::Serialize;
 use crate::passwordless::{Passwordless, PasswordlessSessionId};
 use crate::{WorkOsError, WorkOsResult};
 
-/// The options for [`SendPasswordlessSession`].
+/// The parameters for [`SendPasswordlessSession`].
 #[derive(Debug, Serialize)]
-pub struct SendPasswordlessSessionOptions<'a> {
+pub struct SendPasswordlessSessionParams<'a> {
     /// The ID of the passwordless session to send an email for.
     pub id: &'a PasswordlessSessionId,
 }
@@ -24,7 +24,7 @@ pub trait SendPasswordlessSession {
     /// [WorkOS Docs: Send a Passwordless Session](https://workos.com/docs/reference/magic-link/passwordless-session/send-email)
     async fn send_passwordless_session(
         &self,
-        options: &SendPasswordlessSessionOptions<'_>,
+        params: &SendPasswordlessSessionParams<'_>,
     ) -> WorkOsResult<(), SendPasswordlessSessionError>;
 }
 
@@ -32,18 +32,18 @@ pub trait SendPasswordlessSession {
 impl<'a> SendPasswordlessSession for Passwordless<'a> {
     async fn send_passwordless_session(
         &self,
-        options: &SendPasswordlessSessionOptions<'_>,
+        params: &SendPasswordlessSessionParams<'_>,
     ) -> WorkOsResult<(), SendPasswordlessSessionError> {
-        let url = self.workos.base_url().join(&format!(
-            "/passwordless/sessions/{id}/send",
-            id = options.id
-        ))?;
+        let url = self
+            .workos
+            .base_url()
+            .join(&format!("/passwordless/sessions/{id}/send", id = params.id))?;
         let response = self
             .workos
             .client()
             .post(url)
             .bearer_auth(self.workos.key())
-            .json(&options)
+            .json(&params)
             .send()
             .await?;
 
@@ -87,7 +87,7 @@ mod test {
 
         let result = workos
             .passwordless()
-            .send_passwordless_session(&SendPasswordlessSessionOptions {
+            .send_passwordless_session(&SendPasswordlessSessionParams {
                 id: &PasswordlessSessionId::from("passwordless_session_01EG1BHJMVYMFBQYZTTC0N73CR"),
             })
             .await;

--- a/src/sso/operations/delete_connection.rs
+++ b/src/sso/operations/delete_connection.rs
@@ -6,9 +6,9 @@ use thiserror::Error;
 use crate::sso::{ConnectionId, Sso};
 use crate::{WorkOsError, WorkOsResult};
 
-/// The options for [`DeleteConnection`].
+/// The parameters for [`DeleteConnection`].
 #[derive(Debug, Serialize)]
-pub struct DeleteConnectionOptions<'a> {
+pub struct DeleteConnectionParams<'a> {
     /// The ID of the connection to delete.
     pub connection_id: &'a ConnectionId,
 }
@@ -31,7 +31,7 @@ pub trait DeleteConnection {
     /// [WorkOS Docs: Delete a Connection](https://workos.com/docs/reference/sso/connection/delete)
     async fn delete_connection(
         &self,
-        options: &DeleteConnectionOptions<'_>,
+        params: &DeleteConnectionParams<'_>,
     ) -> WorkOsResult<(), DeleteConnectionError>;
 }
 
@@ -39,12 +39,12 @@ pub trait DeleteConnection {
 impl<'a> DeleteConnection for Sso<'a> {
     async fn delete_connection(
         &self,
-        options: &DeleteConnectionOptions<'_>,
+        params: &DeleteConnectionParams<'_>,
     ) -> WorkOsResult<(), DeleteConnectionError> {
         let url = self
             .workos
             .base_url()
-            .join(&format!("/connections/{id}", id = options.connection_id))?;
+            .join(&format!("/connections/{id}", id = params.connection_id))?;
         let response = self
             .workos
             .client()
@@ -88,7 +88,7 @@ mod test {
 
         let result = workos
             .sso()
-            .delete_connection(&DeleteConnectionOptions {
+            .delete_connection(&DeleteConnectionParams {
                 connection_id: &ConnectionId::from("conn_01E2NPPCT7XQ2MVVYDHWGK1WN4"),
             })
             .await;

--- a/src/sso/operations/get_authorization_url.rs
+++ b/src/sso/operations/get_authorization_url.rs
@@ -26,9 +26,9 @@ pub enum ConnectionSelector<'a> {
     Provider(&'a Provider),
 }
 
-/// The options for [`GetAuthorizationUrl`].
+/// The parameters for [`GetAuthorizationUrl`].
 #[derive(Debug)]
-pub struct GetAuthorizationUrlOptions<'a> {
+pub struct GetAuthorizationUrlParams<'a> {
     /// The client ID for the environment in which SSO is being initiated.
     ///
     /// This value can be obtained from the "Configuration" page in the WorkOS Dashboard.
@@ -49,23 +49,17 @@ pub trait GetAuthorizationUrl {
     /// Returns an authorization URL to use to initiate SSO.
     ///
     /// [WorkOS Docs: Get Authorization URL](https://workos.com/docs/reference/sso/authorize/get)
-    fn get_authorization_url(
-        &self,
-        options: &GetAuthorizationUrlOptions,
-    ) -> Result<Url, ParseError>;
+    fn get_authorization_url(&self, params: &GetAuthorizationUrlParams) -> Result<Url, ParseError>;
 }
 
 impl<'a> GetAuthorizationUrl for Sso<'a> {
-    fn get_authorization_url(
-        &self,
-        options: &GetAuthorizationUrlOptions,
-    ) -> Result<Url, ParseError> {
-        let GetAuthorizationUrlOptions {
+    fn get_authorization_url(&self, params: &GetAuthorizationUrlParams) -> Result<Url, ParseError> {
+        let GetAuthorizationUrlParams {
             connection_selector,
             client_id,
             redirect_uri,
             state,
-        } = options;
+        } = params;
 
         let query = {
             let client_id = client_id.to_string();
@@ -117,7 +111,7 @@ mod test {
         let workos_sso = Sso::new(&workos);
 
         let authorization_url = workos_sso
-            .get_authorization_url(&GetAuthorizationUrlOptions {
+            .get_authorization_url(&GetAuthorizationUrlParams {
                 client_id: &ClientId::from("client_123456789"),
                 redirect_uri: "https://your-app.com/callback",
                 connection_selector: ConnectionSelector::Connection(&ConnectionId::from(
@@ -142,7 +136,7 @@ mod test {
         let workos_sso = Sso::new(&workos);
 
         let authorization_url = workos_sso
-            .get_authorization_url(&GetAuthorizationUrlOptions {
+            .get_authorization_url(&GetAuthorizationUrlParams {
                 client_id: &ClientId::from("client_123456789"),
                 redirect_uri: "https://your-app.com/callback",
                 connection_selector: ConnectionSelector::Organization(&OrganizationId::from(
@@ -167,7 +161,7 @@ mod test {
         let workos_sso = Sso::new(&workos);
 
         let authorization_url = workos_sso
-            .get_authorization_url(&GetAuthorizationUrlOptions {
+            .get_authorization_url(&GetAuthorizationUrlParams {
                 client_id: &ClientId::from("client_123456789"),
                 redirect_uri: "https://your-app.com/callback",
                 connection_selector: ConnectionSelector::Provider(&Provider::GoogleOauth),

--- a/src/sso/operations/get_profile_and_token.rs
+++ b/src/sso/operations/get_profile_and_token.rs
@@ -6,9 +6,9 @@ use thiserror::Error;
 use crate::sso::{AccessToken, AuthorizationCode, ClientId, Profile, Sso};
 use crate::{WorkOsError, WorkOsResult};
 
-/// The options for [`GetProfileAndToken`].
+/// The parameters for [`GetProfileAndToken`].
 #[derive(Debug)]
-pub struct GetProfileAndTokenOptions<'a> {
+pub struct GetProfileAndTokenParams<'a> {
     /// The client ID corresponding to the environment that SSO was initiated
     /// from.
     pub client_id: &'a ClientId,
@@ -44,7 +44,7 @@ pub trait GetProfileAndToken {
     /// [WorkOS Docs: Get a Profile and Token](https://workos.com/docs/reference/sso/profile/token)
     async fn get_profile_and_token(
         &self,
-        options: &GetProfileAndTokenOptions<'_>,
+        params: &GetProfileAndTokenParams<'_>,
     ) -> WorkOsResult<GetProfileAndTokenResponse, GetProfileAndTokenError>;
 }
 
@@ -52,9 +52,9 @@ pub trait GetProfileAndToken {
 impl<'a> GetProfileAndToken for Sso<'a> {
     async fn get_profile_and_token(
         &self,
-        options: &GetProfileAndTokenOptions<'_>,
+        params: &GetProfileAndTokenParams<'_>,
     ) -> WorkOsResult<GetProfileAndTokenResponse, GetProfileAndTokenError> {
-        let &GetProfileAndTokenOptions { client_id, code } = options;
+        let &GetProfileAndTokenParams { client_id, code } = params;
 
         let url = self.workos.base_url().join("/sso/token")?;
         let params = [
@@ -138,7 +138,7 @@ mod test {
 
         let response = workos
             .sso()
-            .get_profile_and_token(&GetProfileAndTokenOptions {
+            .get_profile_and_token(&GetProfileAndTokenParams {
                 client_id: &ClientId::from("client_1234"),
                 code: &AuthorizationCode::from("abc123"),
             })
@@ -175,7 +175,7 @@ mod test {
 
         let result = workos
             .sso()
-            .get_profile_and_token(&GetProfileAndTokenOptions {
+            .get_profile_and_token(&GetProfileAndTokenParams {
                 client_id: &ClientId::from("client_1234"),
                 code: &AuthorizationCode::from("abc123"),
             })
@@ -204,7 +204,7 @@ mod test {
 
         let result = workos
             .sso()
-            .get_profile_and_token(&GetProfileAndTokenOptions {
+            .get_profile_and_token(&GetProfileAndTokenParams {
                 client_id: &ClientId::from("client_1234"),
                 code: &AuthorizationCode::from("abc123"),
             })
@@ -233,7 +233,7 @@ mod test {
 
         let result = workos
             .sso()
-            .get_profile_and_token(&GetProfileAndTokenOptions {
+            .get_profile_and_token(&GetProfileAndTokenParams {
                 client_id: &ClientId::from("client_1234"),
                 code: &AuthorizationCode::from("abc123"),
             })

--- a/src/sso/operations/list_connections.rs
+++ b/src/sso/operations/list_connections.rs
@@ -4,14 +4,14 @@ use serde::Serialize;
 
 use crate::organizations::OrganizationId;
 use crate::sso::{Connection, ConnectionType, Sso};
-use crate::{KnownOrUnknown, PaginatedList, PaginationOptions, WorkOsError, WorkOsResult};
+use crate::{KnownOrUnknown, PaginatedList, PaginationParams, WorkOsError, WorkOsResult};
 
-/// The options for [`ListConnections`].
+/// The parameters for [`ListConnections`].
 #[derive(Debug, Serialize)]
-pub struct ListConnectionsOptions<'a> {
+pub struct ListConnectionsParams<'a> {
     /// The pagination options to use when listing connections.
     #[serde(flatten)]
-    pub pagination: PaginationOptions<'a>,
+    pub pagination: PaginationParams<'a>,
 
     /// The ID of the organization to list connections for.
     pub organization_id: Option<&'a OrganizationId>,
@@ -21,10 +21,10 @@ pub struct ListConnectionsOptions<'a> {
     pub r#type: &'a Option<KnownOrUnknown<ConnectionType, String>>,
 }
 
-impl<'a> Default for ListConnectionsOptions<'a> {
+impl<'a> Default for ListConnectionsParams<'a> {
     fn default() -> Self {
         Self {
-            pagination: PaginationOptions::default(),
+            pagination: PaginationParams::default(),
             organization_id: None,
             r#type: &None,
         }
@@ -39,7 +39,7 @@ pub trait ListConnections {
     /// [WorkOS Docs: List Connections](https://workos.com/docs/reference/sso/connection/list)
     async fn list_connections(
         &self,
-        options: &ListConnectionsOptions<'_>,
+        params: &ListConnectionsParams<'_>,
     ) -> WorkOsResult<PaginatedList<Connection>, ()>;
 }
 
@@ -47,14 +47,14 @@ pub trait ListConnections {
 impl<'a> ListConnections for Sso<'a> {
     async fn list_connections(
         &self,
-        options: &ListConnectionsOptions<'_>,
+        params: &ListConnectionsParams<'_>,
     ) -> WorkOsResult<PaginatedList<Connection>, ()> {
         let url = self.workos.base_url().join("/connections")?;
         let response = self
             .workos
             .client()
             .get(url)
-            .query(&options)
+            .query(&params)
             .bearer_auth(self.workos.key())
             .send()
             .await?;
@@ -179,7 +179,7 @@ mod test {
 
         let paginated_list = workos
             .sso()
-            .list_connections(&ListConnectionsOptions {
+            .list_connections(&ListConnectionsParams {
                 r#type: &Some(KnownOrUnknown::Known(ConnectionType::OktaSaml)),
                 ..Default::default()
             })

--- a/src/sso/operations/list_connections.rs
+++ b/src/sso/operations/list_connections.rs
@@ -9,7 +9,7 @@ use crate::{KnownOrUnknown, PaginatedList, PaginationParams, WorkOsError, WorkOs
 /// The parameters for [`ListConnections`].
 #[derive(Debug, Serialize)]
 pub struct ListConnectionsParams<'a> {
-    /// The pagination options to use when listing connections.
+    /// The pagination parameters to use when listing connections.
     #[serde(flatten)]
     pub pagination: PaginationParams<'a>,
 


### PR DESCRIPTION
This PR replaces `Options` terminology with `Params`, as it is a bit clearer.

Resolves SDK-505.