### PR TITLE
[Merged by Bors] - Use `Active`/`Inactive` in `DirectoryState`

### DIFF
--- a/src/directory_sync/types/directory.rs
+++ b/src/directory_sync/types/directory.rs
@@ -32,20 +32,22 @@ impl From<&str> for DirectoryId {
 #[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum DirectoryState {
-    /// The directory is linked.
-    Linked,
+    /// The directory is inactve.
+    #[serde(alias = "unlinked")]
+    Inactive,
 
-    /// The directory is unlinked.
-    Unlinked,
-
-    /// The directory is attemping to link.
+    /// The directory is being validated.
     Validating,
+
+    /// The directory is active.
+    #[serde(alias = "linked")]
+    Active,
+
+    /// The directory encountered an issue with invalid credentials.
+    InvalidCredentials,
 
     /// The directory is being deleted.
     Deleting,
-
-    /// The directory was unable to link due to invalid credentials.
-    InvalidCredentials,
 }
 
 /// [WorkOS Docs: Directory](https://workos.com/docs/reference/directory-sync/directory)
@@ -109,7 +111,7 @@ mod test {
                 organization_id: Some(OrganizationId::from("org_01EHZNVPK3SFK441A1RGBFSHRT")),
                 r#type: KnownOrUnknown::Known(DirectoryType::BambooHr),
                 name: "Foo Corp".to_string(),
-                state: KnownOrUnknown::Known(DirectoryState::Unlinked),
+                state: KnownOrUnknown::Known(DirectoryState::Inactive),
                 timestamps: Timestamps {
                     created_at: Timestamp::try_from("2021-06-25T19:07:33.155Z").unwrap(),
                     updated_at: Timestamp::try_from("2021-06-25T19:07:33.155Z").unwrap(),

--- a/src/webhooks/types/directory.rs
+++ b/src/webhooks/types/directory.rs
@@ -2,9 +2,9 @@ use std::fmt::Display;
 
 use serde::{Deserialize, Serialize};
 
-use crate::{
-    directory_sync::DirectoryType, organizations::OrganizationId, KnownOrUnknown, Timestamps,
-};
+use crate::directory_sync::{DirectoryState, DirectoryType};
+use crate::organizations::OrganizationId;
+use crate::{KnownOrUnknown, Timestamps};
 
 /// The ID of a [`Directory`].
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
@@ -26,17 +26,6 @@ impl From<&str> for DirectoryId {
     fn from(value: &str) -> Self {
         Self(value.to_string())
     }
-}
-
-/// The state of a [`Directory`].
-#[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
-pub enum DirectoryState {
-    /// The directory is linked.
-    Active,
-
-    /// The directory is unlinked.
-    Inactive,
 }
 
 /// [WorkOS Docs: Directory](https://workos.com/docs/reference/directory-sync/directory)

--- a/src/webhooks/types/events/directory_activated.rs
+++ b/src/webhooks/types/events/directory_activated.rs
@@ -10,11 +10,10 @@ pub struct DirectoryActivatedWebhook(pub Directory);
 mod test {
     use serde_json::json;
 
-    use crate::directory_sync::DirectoryType;
+    use crate::directory_sync::{DirectoryState, DirectoryType};
     use crate::organizations::OrganizationId;
     use crate::webhooks::{
-        Directory, DirectoryActivatedWebhook, DirectoryId, DirectoryState, Webhook, WebhookEvent,
-        WebhookId,
+        Directory, DirectoryActivatedWebhook, DirectoryId, Webhook, WebhookEvent, WebhookId,
     };
     use crate::{KnownOrUnknown, Timestamp, Timestamps};
 


### PR DESCRIPTION
This PR updates the `DirectoryState` to use `Active`/`Inactive` instead of `Linked`/`Unlinked`.

We're aliasing the variant values in `serde` so that we can support both sets of values coming back from the API.

Resolves SDK-531.