### PR TITLE
[Merged by Bors] - Move lifetimes inside of `Option`s

### DIFF
--- a/src/core/types/pagination_params.rs
+++ b/src/core/types/pagination_params.rs
@@ -7,18 +7,18 @@ pub struct PaginationParams<'a> {
     pub order: &'a PaginationOrder,
 
     /// The cursor after which records should be retrived.
-    pub after: &'a Option<String>,
+    pub after: Option<&'a str>,
 
     /// The cursor before which records should be retrieved.
-    pub before: &'a Option<String>,
+    pub before: Option<&'a str>,
 }
 
 impl<'a> Default for PaginationParams<'a> {
     fn default() -> Self {
         Self {
             order: &PaginationOrder::DEFAULT,
-            before: &None,
-            after: &None,
+            before: None,
+            after: None,
         }
     }
 }

--- a/src/directory_sync/operations/list_directories.rs
+++ b/src/directory_sync/operations/list_directories.rs
@@ -6,7 +6,7 @@ use crate::organizations::OrganizationId;
 use crate::{KnownOrUnknown, PaginatedList, PaginationParams, ResponseExt, WorkOsResult};
 
 /// The parameters for [`ListDirectories`].
-#[derive(Debug, Serialize)]
+#[derive(Debug, Default, Serialize)]
 pub struct ListDirectoriesParams<'a> {
     /// The domain of a directory.
     pub domain: Option<&'a String>,
@@ -23,19 +23,7 @@ pub struct ListDirectoriesParams<'a> {
 
     /// The type of directories to list.
     #[serde(rename = "directory_type")]
-    pub r#type: &'a Option<KnownOrUnknown<DirectoryType, String>>,
-}
-
-impl<'a> Default for ListDirectoriesParams<'a> {
-    fn default() -> Self {
-        Self {
-            pagination: PaginationParams::default(),
-            organization_id: None,
-            r#type: &None,
-            domain: None,
-            search: None,
-        }
-    }
+    pub r#type: Option<KnownOrUnknown<&'a DirectoryType, &'a str>>,
 }
 
 /// [WorkOS Docs: List Directories](https://workos.com/docs/reference/directory-sync/directory/list)
@@ -180,7 +168,7 @@ mod test {
         let paginated_list = workos
             .directory_sync()
             .list_directories(&ListDirectoriesParams {
-                r#type: &Some(KnownOrUnknown::Known(DirectoryType::GoogleWorkspace)),
+                r#type: Some(KnownOrUnknown::Known(&DirectoryType::GoogleWorkspace)),
                 ..Default::default()
             })
             .await

--- a/src/organizations/operations/list_organizations.rs
+++ b/src/organizations/operations/list_organizations.rs
@@ -18,7 +18,7 @@ impl<'a> From<Vec<&'a str>> for DomainFilters<'a> {
 }
 
 /// Parameters for the [`ListOrganizations`] function.
-#[derive(Debug, Serialize)]
+#[derive(Debug, Default, Serialize)]
 pub struct ListOrganizationsParams<'a> {
     /// The pagination parameters to use when listing organizations.
     #[serde(flatten)]
@@ -27,15 +27,6 @@ pub struct ListOrganizationsParams<'a> {
     /// The domains of Organizations to be listed.
     #[serde(rename = "domains[]")]
     pub domains: Option<DomainFilters<'a>>,
-}
-
-impl<'a> Default for ListOrganizationsParams<'a> {
-    fn default() -> Self {
-        Self {
-            pagination: PaginationParams::default(),
-            domains: None,
-        }
-    }
 }
 
 /// An error returned from [`ListOrganizations`].

--- a/src/sso/operations/list_connections.rs
+++ b/src/sso/operations/list_connections.rs
@@ -6,7 +6,7 @@ use crate::sso::{Connection, ConnectionType, Sso};
 use crate::{KnownOrUnknown, PaginatedList, PaginationParams, ResponseExt, WorkOsResult};
 
 /// The parameters for [`ListConnections`].
-#[derive(Debug, Serialize)]
+#[derive(Debug, Default, Serialize)]
 pub struct ListConnectionsParams<'a> {
     /// The pagination parameters to use when listing connections.
     #[serde(flatten)]
@@ -17,17 +17,7 @@ pub struct ListConnectionsParams<'a> {
 
     /// The type of connections to list.
     #[serde(rename = "connection_type")]
-    pub r#type: &'a Option<KnownOrUnknown<ConnectionType, String>>,
-}
-
-impl<'a> Default for ListConnectionsParams<'a> {
-    fn default() -> Self {
-        Self {
-            pagination: PaginationParams::default(),
-            organization_id: None,
-            r#type: &None,
-        }
-    }
+    pub r#type: Option<KnownOrUnknown<&'a ConnectionType, &'a str>>,
 }
 
 /// [WorkOS Docs: List Connections](https://workos.com/docs/reference/sso/connection/list)
@@ -171,7 +161,7 @@ mod test {
         let paginated_list = workos
             .sso()
             .list_connections(&ListConnectionsParams {
-                r#type: &Some(KnownOrUnknown::Known(ConnectionType::OktaSaml)),
+                r#type: Some(KnownOrUnknown::Known(&ConnectionType::OktaSaml)),
                 ..Default::default()
             })
             .await


### PR DESCRIPTION
This PR moves the lifetimes inside of the `Option`s for parameters to list operations.