### PR TITLE
[Merged by Bors] - Rename `VerifyFactor` to `VerifyChallenge`

### DIFF
--- a/src/mfa/operations.rs
+++ b/src/mfa/operations.rs
@@ -1,7 +1,7 @@
 mod challenge_factor;
 mod enroll_factor;
-mod verify_factor;
+mod verify_challenge;
 
 pub use challenge_factor::*;
 pub use enroll_factor::*;
-pub use verify_factor::*;
+pub use verify_challenge::*;

--- a/src/sso/operations/get_authorization_url.rs
+++ b/src/sso/operations/get_authorization_url.rs
@@ -65,9 +65,9 @@ pub trait GetAuthorizationUrl {
     ///     .get_authorization_url(&GetAuthorizationUrlParams {
     ///         client_id: &ClientId::from("client_123456789"),
     ///         redirect_uri: "https://your-app.com/callback",
-    ///         connection_selector: ConnectionSelector::Connection(
-    ///             &ConnectionId::from("conn_01E4ZCR3C56J083X43JQXF3JK5")
-    ///         ),
+    ///         connection_selector: ConnectionSelector::Connection(&ConnectionId::from(
+    ///             "conn_01E4ZCR3C56J083X43JQXF3JK5",
+    ///         )),
     ///         state: None,
     ///     })?;
     /// # Ok(())


### PR DESCRIPTION
This PR renames the `VerifyFactor` operation to `VerifyChallenge`, since the latter is more accurate.

Resolves SDK-540.