### PR TITLE
[Merged by Bors] - Organize imports

### DIFF
--- a/src/admin_portal/operations/generate_portal_link.rs
+++ b/src/admin_portal/operations/generate_portal_link.rs
@@ -122,7 +122,8 @@ mod test {
     use serde_json::json;
     use tokio;
 
-    use crate::{organizations::OrganizationId, ApiKey, WorkOs};
+    use crate::organizations::OrganizationId;
+    use crate::{ApiKey, WorkOs};
 
     use super::*;
 

--- a/src/core/types/url_encodable_vec.rs
+++ b/src/core/types/url_encodable_vec.rs
@@ -1,8 +1,6 @@
-use std::fmt::Display;
-use std::fmt::Write;
+use std::fmt::{Display, Write};
 
-use serde::Serialize;
-use serde::{ser, Serializer};
+use serde::{ser, Serialize, Serializer};
 
 /// A [`Vec`] that can be URL-encoded.
 #[derive(Debug)]

--- a/src/directory_sync/operations/list_directories.rs
+++ b/src/directory_sync/operations/list_directories.rs
@@ -87,7 +87,8 @@ mod test {
     use serde_json::json;
     use tokio;
 
-    use crate::{directory_sync::DirectoryId, ApiKey, WorkOs};
+    use crate::directory_sync::DirectoryId;
+    use crate::{ApiKey, WorkOs};
 
     use super::*;
 

--- a/src/directory_sync/operations/list_directory_groups.rs
+++ b/src/directory_sync/operations/list_directory_groups.rs
@@ -95,7 +95,8 @@ mod test {
     use serde_json::json;
     use tokio;
 
-    use crate::{directory_sync::DirectoryGroupId, ApiKey, WorkOs};
+    use crate::directory_sync::DirectoryGroupId;
+    use crate::{ApiKey, WorkOs};
 
     use super::*;
 

--- a/src/directory_sync/operations/list_directory_users.rs
+++ b/src/directory_sync/operations/list_directory_users.rs
@@ -95,7 +95,8 @@ mod test {
     use serde_json::json;
     use tokio;
 
-    use crate::{directory_sync::DirectoryUserId, ApiKey, WorkOs};
+    use crate::directory_sync::DirectoryUserId;
+    use crate::{ApiKey, WorkOs};
 
     use super::*;
 

--- a/src/directory_sync/types/directory.rs
+++ b/src/directory_sync/types/directory.rs
@@ -2,9 +2,9 @@ use std::fmt::Display;
 
 use serde::{Deserialize, Serialize};
 
-use crate::{
-    directory_sync::DirectoryType, organizations::OrganizationId, KnownOrUnknown, Timestamps,
-};
+use crate::directory_sync::DirectoryType;
+use crate::organizations::OrganizationId;
+use crate::{KnownOrUnknown, Timestamps};
 
 /// The ID of a [`Directory`].
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]

--- a/src/directory_sync/types/directory_group.rs
+++ b/src/directory_sync/types/directory_group.rs
@@ -2,7 +2,8 @@ use std::fmt::Display;
 
 use serde::{Deserialize, Serialize};
 
-use crate::{directory_sync::DirectoryId, RawAttributes, Timestamps};
+use crate::directory_sync::DirectoryId;
+use crate::{RawAttributes, Timestamps};
 
 /// The ID of a [`DirectoryGroup`].
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]

--- a/src/mfa/operations/challenge_factor.rs
+++ b/src/mfa/operations/challenge_factor.rs
@@ -79,10 +79,8 @@ mod test {
     use serde_json::json;
     use tokio;
 
-    use crate::{
-        mfa::{AuthenticationChallengeId, AuthenticationFactorId},
-        ApiKey, WorkOs,
-    };
+    use crate::mfa::{AuthenticationChallengeId, AuthenticationFactorId};
+    use crate::{ApiKey, WorkOs};
 
     use super::*;
 

--- a/src/mfa/operations/enroll_factor.rs
+++ b/src/mfa/operations/enroll_factor.rs
@@ -132,7 +132,8 @@ mod test {
     use serde_json::json;
     use tokio;
 
-    use crate::{mfa::AuthenticationFactorId, ApiKey, WorkOs};
+    use crate::mfa::AuthenticationFactorId;
+    use crate::{ApiKey, WorkOs};
 
     use super::*;
 

--- a/src/mfa/operations/verify_challenge.rs
+++ b/src/mfa/operations/verify_challenge.rs
@@ -71,10 +71,8 @@ mod test {
     use serde_json::json;
     use tokio;
 
-    use crate::{
-        mfa::{AuthenticationChallengeId, MfaCode},
-        ApiKey, WorkOs,
-    };
+    use crate::mfa::{AuthenticationChallengeId, MfaCode};
+    use crate::{ApiKey, WorkOs};
 
     use super::*;
 

--- a/src/organizations/operations/create_organization.rs
+++ b/src/organizations/operations/create_organization.rs
@@ -78,7 +78,8 @@ mod test {
     use serde_json::json;
     use tokio;
 
-    use crate::{organizations::OrganizationId, ApiKey, WorkOs};
+    use crate::organizations::OrganizationId;
+    use crate::{ApiKey, WorkOs};
 
     use super::*;
 

--- a/src/organizations/operations/list_organizations.rs
+++ b/src/organizations/operations/list_organizations.rs
@@ -80,7 +80,8 @@ mod test {
     use serde_json::json;
     use tokio;
 
-    use crate::{organizations::OrganizationId, ApiKey, WorkOs};
+    use crate::organizations::OrganizationId;
+    use crate::{ApiKey, WorkOs};
 
     use super::*;
 

--- a/src/organizations/operations/update_organization.rs
+++ b/src/organizations/operations/update_organization.rs
@@ -85,7 +85,8 @@ mod test {
     use serde_json::json;
     use tokio;
 
-    use crate::{organizations::OrganizationId, ApiKey, WorkOs};
+    use crate::organizations::OrganizationId;
+    use crate::{ApiKey, WorkOs};
 
     use super::*;
 

--- a/src/sso/operations/list_connections.rs
+++ b/src/sso/operations/list_connections.rs
@@ -61,7 +61,8 @@ mod test {
     use serde_json::json;
     use tokio;
 
-    use crate::{sso::ConnectionId, ApiKey, WorkOs};
+    use crate::sso::ConnectionId;
+    use crate::{ApiKey, WorkOs};
 
     use super::*;
 

--- a/src/sso/types/profile.rs
+++ b/src/sso/types/profile.rs
@@ -2,7 +2,8 @@ use std::fmt::Display;
 
 use serde::{Deserialize, Serialize};
 
-use crate::{organizations::OrganizationId, KnownOrUnknown, RawAttributes};
+use crate::organizations::OrganizationId;
+use crate::{KnownOrUnknown, RawAttributes};
 
 use super::{ConnectionId, ConnectionType};
 

--- a/src/webhooks/types/directory.rs
+++ b/src/webhooks/types/directory.rs
@@ -1,10 +1,8 @@
 use serde::{Deserialize, Serialize};
 
-use crate::{
-    directory_sync::{DirectoryId, DirectoryType},
-    organizations::OrganizationId,
-    KnownOrUnknown, Timestamps,
-};
+use crate::directory_sync::{DirectoryId, DirectoryType};
+use crate::organizations::OrganizationId;
+use crate::{KnownOrUnknown, Timestamps};
 
 /// The state of a [`Directory`].
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]


### PR DESCRIPTION
This PR organizes imports across the codebase.

I ran `cargo +nightly fmt` with the following options in `rustfmt.toml`:

```toml
unstable_features = true
imports_granularity = "Module"
```

Probably just going to keep doing this by hand until we feel like setting up nightly in CI or the options get stabilized.