### PR TITLE
[Merged by Bors] - Add `organization_id` to `DirectoryUser`s and `DirectoryGroup`s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added `organization_id` to `DirectoryUser`s and `DirectoryGroup`s ([#84](https://github.com/workos/workos-rust/pull/84))
+
 ## [0.1.1] - 2022-07-11
 
 ### Changed

--- a/src/directory_sync/types/directory_group.rs
+++ b/src/directory_sync/types/directory_group.rs
@@ -3,6 +3,7 @@ use std::fmt::Display;
 use serde::{Deserialize, Serialize};
 
 use crate::directory_sync::DirectoryId;
+use crate::organizations::OrganizationId;
 use crate::{RawAttributes, Timestamps};
 
 /// The ID of a [`DirectoryGroup`].
@@ -40,6 +41,9 @@ pub struct DirectoryGroup {
     /// The identifier of the [`Directory`](crate::directory_sync::Directory) the Directory Group belongs to.
     pub directory_id: DirectoryId,
 
+    /// The ID of the organization in which the directory resides.
+    pub organization_id: Option<OrganizationId>,
+
     /// The name of the Directory Group.
     pub name: String,
 
@@ -57,6 +61,7 @@ mod test {
 
     use serde_json::{json, Value};
 
+    use crate::organizations::OrganizationId;
     use crate::{RawAttributes, Timestamp, Timestamps};
 
     use super::{DirectoryGroup, DirectoryGroupId, DirectoryId};
@@ -68,6 +73,7 @@ mod test {
               "id": "directory_group_01E1JJS84MFPPQ3G655FHTKX6Z",
               "idp_id": "02grqrue4294w24",
               "directory_id": "directory_01ECAZ4NV9QMV47GW873HDCX74",
+              "organization_id": "org_01EZTR6WYX1A0DSE2CYMGXQ24Y",
               "name": "Developers",
               "created_at": "2021-06-25T19:07:33.155Z",
               "updated_at": "2021-06-25T19:07:33.155Z",
@@ -87,6 +93,7 @@ mod test {
                 id: DirectoryGroupId::from("directory_group_01E1JJS84MFPPQ3G655FHTKX6Z"),
                 idp_id: "02grqrue4294w24".to_string(),
                 directory_id: DirectoryId::from("directory_01ECAZ4NV9QMV47GW873HDCX74"),
+                organization_id: Some(OrganizationId::from("org_01EZTR6WYX1A0DSE2CYMGXQ24Y")),
                 name: "Developers".to_string(),
                 timestamps: Timestamps {
                     created_at: Timestamp::try_from("2021-06-25T19:07:33.155Z").unwrap(),

--- a/src/directory_sync/types/directory_user.rs
+++ b/src/directory_sync/types/directory_user.rs
@@ -5,6 +5,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
 use crate::directory_sync::DirectoryId;
+use crate::organizations::OrganizationId;
 use crate::{KnownOrUnknown, RawAttributes, Timestamps};
 
 /// The ID of a [`DirectoryUser`].
@@ -41,6 +42,9 @@ pub struct DirectoryUser<TCustomAttributes = HashMap<String, Value>> {
 
     /// The identifier of the [`Directory`](crate::directory_sync::Directory) the directory user belongs to.
     pub directory_id: DirectoryId,
+
+    /// The ID of the organization in which the directory resides.
+    pub organization_id: Option<OrganizationId>,
 
     /// The username of the directory user.
     pub username: Option<String>,
@@ -102,6 +106,7 @@ mod test {
     use serde::Deserialize;
     use serde_json::{json, Value};
 
+    use crate::organizations::OrganizationId;
     use crate::{KnownOrUnknown, RawAttributes, Timestamp, Timestamps};
 
     use super::{
@@ -115,6 +120,7 @@ mod test {
                 "id": "directory_user_01E1JG7J09H96KYP8HM9B0G5SJ",
                 "idp_id": "2836",
                 "directory_id": "directory_01ECAZ4NV9QMV47GW873HDCX74",
+                "organization_id": "org_01EZTR6WYX1A0DSE2CYMGXQ24Y",
                 "first_name": "Marcelina",
                 "last_name": "Davis",
                 "emails": [
@@ -163,6 +169,7 @@ mod test {
                 id: DirectoryUserId::from("directory_user_01E1JG7J09H96KYP8HM9B0G5SJ"),
                 idp_id: "2836".to_string(),
                 directory_id: DirectoryId::from("directory_01ECAZ4NV9QMV47GW873HDCX74"),
+                organization_id: Some(OrganizationId::from("org_01EZTR6WYX1A0DSE2CYMGXQ24Y")),
                 username: Some("marcelina@foo-corp.com".to_string()),
                 emails: vec![DirectoryUserEmail {
                     primary: Some(true),

--- a/src/webhooks/types/events/directory_group_created.rs
+++ b/src/webhooks/types/events/directory_group_created.rs
@@ -14,6 +14,7 @@ mod test {
 
     use crate::directory_sync::{DirectoryGroupId, DirectoryId};
 
+    use crate::organizations::OrganizationId;
     use crate::webhooks::{Webhook, WebhookEvent, WebhookId};
     use crate::{RawAttributes, Timestamp, Timestamps};
 
@@ -30,6 +31,7 @@ mod test {
                   "object": "directory_group",
                   "id": "directory_group_01E1X5GPMMXF4T1DCERMVEEPVW",
                   "directory_id": "directory_01E1X194NTJ3PYMAY79DYV0F0P",
+                  "organization_id": "org_01EZTR6WYX1A0DSE2CYMGXQ24Y",
                   "idp_id": "02grqrue4294w24",
                   "name": "Developers",
                   "created_at": "2021-06-25T19:07:33.155Z",
@@ -58,6 +60,9 @@ mod test {
                         id: DirectoryGroupId::from("directory_group_01E1X5GPMMXF4T1DCERMVEEPVW"),
                         idp_id: "02grqrue4294w24".to_string(),
                         directory_id: DirectoryId::from("directory_01E1X194NTJ3PYMAY79DYV0F0P"),
+                        organization_id: Some(OrganizationId::from(
+                            "org_01EZTR6WYX1A0DSE2CYMGXQ24Y"
+                        )),
                         name: "Developers".to_string(),
                         timestamps: Timestamps {
                             created_at: Timestamp::try_from("2021-06-25T19:07:33.155Z").unwrap(),

--- a/src/webhooks/types/events/directory_group_deleted.rs
+++ b/src/webhooks/types/events/directory_group_deleted.rs
@@ -14,6 +14,7 @@ mod test {
 
     use crate::directory_sync::{DirectoryGroupId, DirectoryId};
 
+    use crate::organizations::OrganizationId;
     use crate::webhooks::{Webhook, WebhookEvent, WebhookId};
     use crate::{RawAttributes, Timestamp, Timestamps};
 
@@ -30,6 +31,7 @@ mod test {
                   "object": "directory_group",
                   "id": "directory_group_01E1X5GPMMXF4T1DCERMVEEPVW",
                   "directory_id": "directory_01E1X194NTJ3PYMAY79DYV0F0P",
+                  "organization_id": "org_01EZTR6WYX1A0DSE2CYMGXQ24Y",
                   "idp_id": "02grqrue4294w24",
                   "name": "Developers",
                   "created_at": "2021-06-25T19:07:33.155Z",
@@ -58,6 +60,9 @@ mod test {
                         id: DirectoryGroupId::from("directory_group_01E1X5GPMMXF4T1DCERMVEEPVW"),
                         idp_id: "02grqrue4294w24".to_string(),
                         directory_id: DirectoryId::from("directory_01E1X194NTJ3PYMAY79DYV0F0P"),
+                        organization_id: Some(OrganizationId::from(
+                            "org_01EZTR6WYX1A0DSE2CYMGXQ24Y"
+                        )),
                         name: "Developers".to_string(),
                         timestamps: Timestamps {
                             created_at: Timestamp::try_from("2021-06-25T19:07:33.155Z").unwrap(),

--- a/src/webhooks/types/events/directory_group_updated.rs
+++ b/src/webhooks/types/events/directory_group_updated.rs
@@ -28,6 +28,7 @@ mod test {
 
     use crate::directory_sync::{DirectoryGroupId, DirectoryId};
 
+    use crate::organizations::OrganizationId;
     use crate::webhooks::{Webhook, WebhookEvent, WebhookId};
     use crate::{RawAttributes, Timestamp, Timestamps};
 
@@ -44,6 +45,7 @@ mod test {
                   "object": "directory_group",
                   "id": "directory_group_01E1X1B89NH8Z3SDFJR4H7RGX7",
                   "directory_id": "directory_01E1X194NTJ3PYMAY79DYV0F0P",
+                  "organization_id": "org_01EZTR6WYX1A0DSE2CYMGXQ24Y",
                   "idp_id": "02grqrue4294w24",
                   "name": "Developers",
                   "created_at": "2021-06-25T19:07:33.155Z",
@@ -81,6 +83,9 @@ mod test {
                             ),
                             idp_id: "02grqrue4294w24".to_string(),
                             directory_id: DirectoryId::from("directory_01E1X194NTJ3PYMAY79DYV0F0P"),
+                            organization_id: Some(OrganizationId::from(
+                                "org_01EZTR6WYX1A0DSE2CYMGXQ24Y"
+                            )),
                             name: "Developers".to_string(),
                             timestamps: Timestamps {
                                 created_at: Timestamp::try_from("2021-06-25T19:07:33.155Z")

--- a/src/webhooks/types/events/directory_group_user_added.rs
+++ b/src/webhooks/types/events/directory_group_user_added.rs
@@ -26,6 +26,7 @@ mod test {
         DirectoryUserId, DirectoryUserState,
     };
 
+    use crate::organizations::OrganizationId;
     use crate::webhooks::{Webhook, WebhookEvent, WebhookId};
     use crate::{KnownOrUnknown, RawAttributes, Timestamp, Timestamps};
 
@@ -41,6 +42,7 @@ mod test {
                 "user": {
                   "id": "directory_user_01E1X56GH84T3FB41SD6PZGDBX",
                   "directory_id": "directory_01ECAZ4NV9QMV47GW873HDCX74",
+                  "organization_id": "org_01EZTR6WYX1A0DSE2CYMGXQ24Y",
                   "idp_id": "1a2b3c4d5e",
                   "emails": [{
                     "primary": true,
@@ -62,6 +64,7 @@ mod test {
                     "id": "directory_group_01E1JJS84MFPPQ3G655FHTKX6Z",
                     "idp_id": "12345",
                     "directory_id": "directory_01ECAZ4NV9QMV47GW873HDCX74",
+                    "organization_id": "org_01EZTR6WYX1A0DSE2CYMGXQ24Y",
                     "name": "Developers",
                     "created_at": "2021-06-25T19:07:33.155Z",
                     "updated_at": "2021-06-25T19:07:33.155Z",
@@ -105,6 +108,9 @@ mod test {
                         },
                         idp_id: "1a2b3c4d5e".to_string(),
                         directory_id: DirectoryId::from("directory_01ECAZ4NV9QMV47GW873HDCX74"),
+                        organization_id: Some(OrganizationId::from(
+                            "org_01EZTR6WYX1A0DSE2CYMGXQ24Y"
+                        )),
                         username: Some("eric@foo-corp.com".to_string()),
                         emails: vec![DirectoryUserEmail {
                             primary: Some(true),
@@ -120,6 +126,9 @@ mod test {
                         id: DirectoryGroupId::from("directory_group_01E1JJS84MFPPQ3G655FHTKX6Z"),
                         idp_id: "12345".to_string(),
                         directory_id: DirectoryId::from("directory_01ECAZ4NV9QMV47GW873HDCX74"),
+                        organization_id: Some(OrganizationId::from(
+                            "org_01EZTR6WYX1A0DSE2CYMGXQ24Y"
+                        )),
                         name: "Developers".to_string(),
                         timestamps: Timestamps {
                             created_at: Timestamp::try_from("2021-06-25T19:07:33.155Z").unwrap(),

--- a/src/webhooks/types/events/directory_group_user_removed.rs
+++ b/src/webhooks/types/events/directory_group_user_removed.rs
@@ -25,6 +25,7 @@ mod test {
         DirectoryGroupId, DirectoryId, DirectoryUser, DirectoryUserEmail, DirectoryUserId,
         DirectoryUserState,
     };
+    use crate::organizations::OrganizationId;
     use crate::webhooks::{Webhook, WebhookEvent, WebhookId};
     use crate::{KnownOrUnknown, RawAttributes, Timestamp, Timestamps};
 
@@ -40,6 +41,7 @@ mod test {
                 "user": {
                   "id": "directory_user_01E1X56GH84T3FB41SD6PZGDBX",
                   "directory_id": "directory_01ECAZ4NV9QMV47GW873HDCX74",
+                  "organization_id": "org_01EZTR6WYX1A0DSE2CYMGXQ24Y",
                   "idp_id": "12345",
                   "emails": [{
                     "primary": true,
@@ -61,6 +63,7 @@ mod test {
                     "id": "directory_group_01E1JJS84MFPPQ3G655FHTKX6Z",
                     "idp_id": "12345",
                     "directory_id": "directory_01ECAZ4NV9QMV47GW873HDCX74",
+                    "organization_id": "org_01EZTR6WYX1A0DSE2CYMGXQ24Y",
                     "name": "Developers",
                     "created_at": "2021-06-25T19:07:33.155Z",
                     "updated_at": "2021-06-25T19:07:33.155Z",
@@ -107,6 +110,9 @@ mod test {
                             },
                             idp_id: "12345".to_string(),
                             directory_id: DirectoryId::from("directory_01ECAZ4NV9QMV47GW873HDCX74"),
+                            organization_id: Some(OrganizationId::from(
+                                "org_01EZTR6WYX1A0DSE2CYMGXQ24Y"
+                            )),
                             username: Some("eric@foo-corp.com".to_string()),
                             emails: vec![DirectoryUserEmail {
                                 primary: Some(true),
@@ -124,6 +130,9 @@ mod test {
                             ),
                             idp_id: "12345".to_string(),
                             directory_id: DirectoryId::from("directory_01ECAZ4NV9QMV47GW873HDCX74"),
+                            organization_id: Some(OrganizationId::from(
+                                "org_01EZTR6WYX1A0DSE2CYMGXQ24Y"
+                            )),
                             name: "Developers".to_string(),
                             timestamps: Timestamps {
                                 created_at: Timestamp::try_from("2021-06-25T19:07:33.155Z")

--- a/src/webhooks/types/events/directory_user_created.rs
+++ b/src/webhooks/types/events/directory_user_created.rs
@@ -16,6 +16,7 @@ mod test {
         DirectoryId, DirectoryUserEmail, DirectoryUserId, DirectoryUserState,
     };
 
+    use crate::organizations::OrganizationId;
     use crate::webhooks::{Webhook, WebhookEvent, WebhookId};
     use crate::{KnownOrUnknown, RawAttributes, Timestamp, Timestamps};
 
@@ -29,6 +30,7 @@ mod test {
               "data": {
                 "id": "directory_user_01E1X1B89NH8Z3SDFJR4H7RGX7",
                 "directory_id": "directory_01ECAZ4NV9QMV47GW873HDCX74",
+                "organization_id": "org_01EZTR6WYX1A0DSE2CYMGXQ24Y",
                 "idp_id": "8931",
                 "emails": [{
                   "primary": true,
@@ -75,6 +77,9 @@ mod test {
                         },
                         idp_id: "8931".to_string(),
                         directory_id: DirectoryId::from("directory_01ECAZ4NV9QMV47GW873HDCX74"),
+                        organization_id: Some(OrganizationId::from(
+                            "org_01EZTR6WYX1A0DSE2CYMGXQ24Y"
+                        )),
                         username: Some("veda@foo-corp.com".to_string()),
                         emails: vec![DirectoryUserEmail {
                             primary: Some(true),

--- a/src/webhooks/types/events/directory_user_deleted.rs
+++ b/src/webhooks/types/events/directory_user_deleted.rs
@@ -16,6 +16,7 @@ mod test {
         DirectoryId, DirectoryUserEmail, DirectoryUserId, DirectoryUserState,
     };
 
+    use crate::organizations::OrganizationId;
     use crate::webhooks::{Webhook, WebhookEvent, WebhookId};
     use crate::{KnownOrUnknown, RawAttributes, Timestamp, Timestamps};
 
@@ -30,6 +31,7 @@ mod test {
               "data": {
                 "object": "directory_user",
                 "directory_id": "directory_01E1X194NTJ3PYMAY79DYV0F0P",
+                "organization_id": "org_01EZTR6WYX1A0DSE2CYMGXQ24Y",
                 "id": "directory_user_01E1X1B89NH8Z3SDFJR4H7RGX7",
                 "idp_id": "8931",
                 "first_name": "Veda",
@@ -78,6 +80,9 @@ mod test {
                         },
                         idp_id: "8931".to_string(),
                         directory_id: DirectoryId::from("directory_01E1X194NTJ3PYMAY79DYV0F0P"),
+                        organization_id: Some(OrganizationId::from(
+                            "org_01EZTR6WYX1A0DSE2CYMGXQ24Y"
+                        )),
                         username: Some("veda@foo-corp.com".to_string()),
                         emails: vec![DirectoryUserEmail {
                             primary: Some(true),

--- a/src/webhooks/types/events/directory_user_updated.rs
+++ b/src/webhooks/types/events/directory_user_updated.rs
@@ -30,6 +30,7 @@ mod test {
         DirectoryId, DirectoryUserEmail, DirectoryUserId, DirectoryUserState,
     };
 
+    use crate::organizations::OrganizationId;
     use crate::webhooks::{Webhook, WebhookEvent, WebhookId};
     use crate::{KnownOrUnknown, RawAttributes, Timestamp, Timestamps};
 
@@ -45,6 +46,7 @@ mod test {
                 "data": {
                   "object": "directory_user",
                   "directory_id": "directory_01E1X194NTJ3PYMAY79DYV0F0P",
+                  "organization_id": "org_01EZTR6WYX1A0DSE2CYMGXQ24Y",
                   "id": "directory_user_01E1X1B89NH8Z3SDFJR4H7RGX7",
                   "idp_id": "8931",
                   "first_name": "Veda",
@@ -105,6 +107,9 @@ mod test {
                             },
                             idp_id: "8931".to_string(),
                             directory_id: DirectoryId::from("directory_01E1X194NTJ3PYMAY79DYV0F0P"),
+                            organization_id: Some(OrganizationId::from(
+                                "org_01EZTR6WYX1A0DSE2CYMGXQ24Y"
+                            )),
                             username: Some("veda@example.com".to_string()),
                             emails: vec![DirectoryUserEmail {
                                 primary: Some(true),


### PR DESCRIPTION
This PR adds an `organization_id` field to `DirectoryUser`s and `DirectoryGroup`s.

Resolves SDK-554.