### PR TITLE
Unship Bors to try out GitHub Merge Queue

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 [![Crates.io](https://img.shields.io/crates/v/workos.svg)](https://crates.io/crates/workos)
 [![Docs.rs](https://docs.rs/workos/badge.svg)](https://docs.rs/workos/)
 [![Crates.io](https://img.shields.io/crates/l/workos.svg)](https://github.com/workos/workos-rust/blob/master/LICENSE)
-[![Bors enabled](https://bors.tech/images/badge_small.svg)](https://merge.workos.dev/repositories/163)
 [![Build Status](https://workos.semaphoreci.com/badges/workos-rust/branches/main.svg?style=shields&key=89f4cdb0-cb76-4ce3-bbcd-46607f9d1287)](https://workos.semaphoreci.com/projects/workos-rust)
 
 > **Note:** this an experimental SDK and breaking changes may occur. We don't recommend using this in production since we can't guarantee its stability.

--- a/bors.toml
+++ b/bors.toml
@@ -1,6 +1,0 @@
-block_labels = []
-required_approvals = 1
-status = ["ci/semaphoreci/push: workos-rust pipeline"]
-delete_merged_branches = true
-update_base_for_deletes = true
-use_squash_merge = true


### PR DESCRIPTION
This PR unships Bors in favor of trying out the new [GitHub Merge Queue](https://github.blog/changelog/2023-02-08-pull-request-merge-queue-public-beta/).

Resolves SDK-649.