### PR TITLE
Remove "suspended" state from Directory Sync user object

### DIFF
--- a/src/directory_sync/types/directory_user.rs
+++ b/src/directory_sync/types/directory_user.rs
@@ -90,9 +90,6 @@ pub enum DirectoryUserState {
 
     /// The directory user is inactive.
     Inactive,
-
-    /// The directory user was suspended from the directory.
-    Suspended,
 }
 
 /// An email address for a [`DirectoryUser`].

--- a/src/webhooks/types/events/directory_user_deleted.rs
+++ b/src/webhooks/types/events/directory_user_deleted.rs
@@ -44,7 +44,7 @@ mod test {
                     "primary": true
                   }
                 ],
-                "state": "suspended",
+                "state": "inactive",
                 "created_at": "2021-06-25T19:07:33.155Z",
                 "updated_at": "2021-06-25T19:07:33.155Z",
                 "raw_attributes": {
@@ -73,7 +73,7 @@ mod test {
                 event: WebhookEvent::DirectoryUserDeleted(DirectoryUserDeletedWebhook(
                     DirectoryUser {
                         id: DirectoryUserId::from("directory_user_01E1X1B89NH8Z3SDFJR4H7RGX7"),
-                        state: KnownOrUnknown::Known(DirectoryUserState::Suspended),
+                        state: KnownOrUnknown::Known(DirectoryUserState::Inactive),
                         timestamps: Timestamps {
                             created_at: Timestamp::try_from("2021-06-25T19:07:33.155Z").unwrap(),
                             updated_at: Timestamp::try_from("2021-06-25T19:07:33.155Z").unwrap()

--- a/src/webhooks/types/events/directory_user_updated.rs
+++ b/src/webhooks/types/events/directory_user_updated.rs
@@ -59,7 +59,7 @@ mod test {
                       "primary": true
                     }
                   ],
-                  "state": "suspended",
+                  "state": "inactive",
                   "created_at": "2021-06-25T19:07:33.155Z",
                   "updated_at": "2021-06-25T19:07:33.155Z",
                   "raw_attributes": {
@@ -98,7 +98,7 @@ mod test {
                     DirectoryUserWithPreviousAttributes {
                         directory_user: DirectoryUser {
                             id: DirectoryUserId::from("directory_user_01E1X1B89NH8Z3SDFJR4H7RGX7"),
-                            state: KnownOrUnknown::Known(DirectoryUserState::Suspended),
+                            state: KnownOrUnknown::Known(DirectoryUserState::Inactive),
                             timestamps: Timestamps {
                                 created_at: Timestamp::try_from("2021-06-25T19:07:33.155Z")
                                     .unwrap(),


### PR DESCRIPTION
"suspended" state is now deprecated and consolidated into the "inactive" state