### PR TITLE
Remove "domain" param from list directories query

### DIFF
--- a/src/directory_sync/operations/list_directories.rs
+++ b/src/directory_sync/operations/list_directories.rs
@@ -8,9 +8,6 @@ use crate::{KnownOrUnknown, PaginatedList, PaginationParams, ResponseExt, WorkOs
 /// The parameters for [`ListDirectories`].
 #[derive(Debug, Default, Serialize)]
 pub struct ListDirectoriesParams<'a> {
-    /// The domain of a directory.
-    pub domain: Option<&'a String>,
-
     /// Searchable text to match against Directory names.
     pub search: Option<&'a String>,
 


### PR DESCRIPTION
## Description
We no longer support querying directories by domain.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.